### PR TITLE
Free PeerConnectionObserver in PeerConnectionManager::hangUp()

### DIFF
--- a/inc/PeerConnectionManager.h
+++ b/inc/PeerConnectionManager.h
@@ -88,7 +88,9 @@ class PeerConnectionManager {
 
 			virtual ~PeerConnectionObserver() { 
 				LOG(INFO) << __PRETTY_FUNCTION__;
-				m_dataChannel->UnregisterObserver(); 
+				if (m_dataChannel) {
+					m_dataChannel->UnregisterObserver();
+				}
 				m_pc->Close(); 
 			}
 			

--- a/src/PeerConnectionManager.cpp
+++ b/src/PeerConnectionManager.cpp
@@ -424,7 +424,8 @@ bool PeerConnectionManager::hangUp(const std::string &peerid)
 	if (it != peer_connectionobs_map_.end())
 	{
 		LOG(LS_ERROR) << "Close PeerConnection";
-		rtc::scoped_refptr<webrtc::PeerConnectionInterface> peerConnection = it->second->getPeerConnection();
+		PeerConnectionObserver* pcObserver = it->second;
+		rtc::scoped_refptr<webrtc::PeerConnectionInterface> peerConnection = pcObserver->getPeerConnection();
 		peer_connectionobs_map_.erase(it);
 		
 		rtc::scoped_refptr<webrtc::StreamCollectionInterface> localstreams (peerConnection->local_streams());
@@ -456,7 +457,8 @@ bool PeerConnectionManager::hangUp(const std::string &peerid)
 				}		
 			}			
 		}
-		
+
+		delete pcObserver;
 		result = true;			
 	}
 	


### PR DESCRIPTION
PeerConnectionObserver instances are created and owned by the
PeerConnectionManager. They are tracked internally using
`peer_connectionobs_map_`, from which they are removed in `hangUp()`.

While the pointer was removed from the map, the instance itself was not
deallocated so far. This meant that memory leaked, and
~PeerConnectionObserver was never called. This also meant that the
PeerConnection was not closed, keeping the associated fds in use. This
patch explicitly names the pointer for clarity, and deletes the
PeerConnectionObserver at the end of `hangUp()`.

In ~PeerConnectionManager, m_dataChannel was assumed to be non-null at
all times. However, in normal operation data channels are not set up,
leaving the pointer in its NULL initial state. This patch adds a check,
and only unregisters observers when a data channel was actually set up.