### PR TITLE
The turn url is not parsed correctly if using username and password

### DIFF
--- a/src/PeerConnectionManager.cpp
+++ b/src/PeerConnectionManager.cpp
@@ -62,6 +62,7 @@ PeerConnectionManager::PeerConnectionManager(const std::string & stunurl, const 
 		if (pos != std::string::npos)
 		{
 			std::string credentials = turnurl_.substr(0, pos);
+			turnurl_ = turnurl_.substr(pos + 1);
 			pos = credentials.find(':');
 			if (pos == std::string::npos)
 			{
@@ -72,7 +73,6 @@ PeerConnectionManager::PeerConnectionManager(const std::string & stunurl, const 
 				turnuser_ = credentials.substr(0, pos);
 				turnpass_ = credentials.substr(pos + 1);
 			}
-			turnurl_ = turnurl_.substr(pos + 1);
 		}
 	}
 


### PR DESCRIPTION
if webrtc-streamer is used with a turn-server that needs username and password the turn-url is parsed incorrectly.
e.g. ./webrtc-streamer -t test:123456@turn.example.com
led to
username: test
credential: 123456
url: turn:123456@turn.example.com

moving the extraction of the turnurl up a few lines before reassigning 'pos' to the position of the colon that seperates the username and password, should do it.