### PR TITLE
Add check in CMakeLists.txt to stop 7z silently failing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,15 @@ target_link_libraries (${PROJECT_NAME} webrtcextra)
 
 # live555helper & live555
 if (NOT EXISTS live)
-	file (DOWNLOAD http://www.live555.com/liveMedia/public/live555-latest.tar.gz ${CMAKE_SOURCE_DIR}/live555-latest.tar.gz )
-    EXECUTE_PROCESS(COMMAND 7z x live555-latest.tar.gz -so COMMAND 7z x -aoa -ttar -si)
+    file (DOWNLOAD http://www.live555.com/liveMedia/public/live555-latest.tar.gz ${CMAKE_SOURCE_DIR}/live555-latest.tar.gz )
+    EXECUTE_PROCESS(
+        COMMAND 7z x live555-latest.tar.gz -so
+        COMMAND 7z x -aoa -ttar -si
+        RESULT_VARIABLE p7z_result
+    )
+    if(NOT p7z_result STREQUAL "0")
+        message(FATAL_ERROR "Fetching and compiling live555 failed!")
+    endif()
 endif(NOT EXISTS live) 
 
 FILE(GLOB LIVEHELPERSOURCE live/groupsock/*.c* live/liveMedia/*.c* live/UsageEnvironment/*.c* live/BasicUsageEnvironment/*.c* live555helper/src/*.cpp)


### PR DESCRIPTION
## Description
When I was compiling I had missed a dependency on 7zip, which I did not have on my system. This caused the unpacking of live555 to fail silently, which resulted in build errors. Took me a little while to figure out why as I initially tried to download, compile and install live555 myself, not realising the webrtc-streamer project was trying to do it itself.

To stop this silent fail I have added a small bit of error detection into the CMakeLists.txt file.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
