### PR TITLE
cast to 64-bit integer to reduce overflow errors

### DIFF
--- a/src/rtspvideocapturer.cpp
+++ b/src/rtspvideocapturer.cpp
@@ -246,7 +246,8 @@ int32_t RTSPVideoCapturer::Decoded(webrtc::VideoFrame& decodedImage)
 				<< " source ts:" << ts;
 
 	// restore the timestamp that had overflow in the convertion EncodedImage.SetTimeStamp(presentationTime)
-	decodedImage.set_timestamp_us(decodedImage.timestamp()*1000);
+	// rdp timestamp is just 32 bit, overflow error will occur each ~50 days
+	decodedImage.set_timestamp_us((int64_t)decodedImage.timestamp() * 1000);
 
 	if ( (m_height == 0) && (m_width == 0) ) {
 		this->OnFrame(decodedImage, decodedImage.height(), decodedImage.width());	


### PR DESCRIPTION
Currently, an overflow error will occur each ~71 minutes. With this commit each ~50 days.
Quick improvement (but no solution) for #187.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
