### PR TITLE
Change to allow multiple webcams with same name.

### DIFF
--- a/inc/CapturerFactory.h
+++ b/inc/CapturerFactory.h
@@ -65,7 +65,9 @@ class VcmCapturer : public rtc::VideoSinkInterface<webrtc::VideoFrame>,  public 
 		char id[kSize] = {0};
 		if (device_info->GetDeviceName(i, name, kSize, id, kSize) == 0)
 		{
-			if (videourl == name) {
+			std::stringstream ss;
+			ss << name << id;
+			if (videourl == ss.str()) {
 				deviceId = id;
 				break;
 			}
@@ -163,7 +165,9 @@ class CapturerFactory {
 					if (info->GetDeviceName(i, name, kSize, id, kSize) != -1)
 					{
 						RTC_LOG(INFO) << "video device name:" << name << " id:" << id;
-						videoDeviceList.push_back(name);
+						std::stringstream ss;
+						ss << name << id;
+						videoDeviceList.push_back(ss.str());
 					}
 				}
 			}


### PR DESCRIPTION
The camera name appears to be based on the make and model. Having
two webcams attached of the same make and model means that one
"hides" the other. The fix is to add the device id into the
string that identifies the camera.

This could be improved by adding a map that would allow us to
use more friendly names like "cam1" "cam2" etc.

## Types of changes

I think you might class this as a breaking change... not sure?

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
