### PR TITLE
new functionality: crop rtsp stream

### DIFF
--- a/inc/rtspvideocapturer.h
+++ b/inc/rtspvideocapturer.h
@@ -99,6 +99,10 @@ class RTSPVideoCapturer : public rtc::VideoSourceInterface<webrtc::VideoFrame>, 
 		std::thread                           m_decoderthread;
 		int                                   m_width;
 		int                                   m_height;
+		int                                   m_roi_x;
+		int                                   m_roi_y;
+		int                                   m_roi_width;
+		int                                   m_roi_height;
 		int                                   m_fps;
 };
 

--- a/src/rtspvideocapturer.cpp
+++ b/src/rtspvideocapturer.cpp
@@ -35,18 +35,46 @@ uint8_t marker[] = { 0, 0, 0, 1};
 RTSPVideoCapturer::RTSPVideoCapturer(const std::string & uri, const std::map<std::string,std::string> & opts) 
 	: m_env(m_stop),
 	m_connection(m_env, this, uri.c_str(), RTSPConnection::decodeTimeoutOption(opts), RTSPConnection::decodeRTPTransport(opts), rtc::LogMessage::GetLogToDebug()<=3),
-	m_width(0), m_height(0), m_fps(0)
+	m_width(0), m_height(0), m_roi_x(0), m_roi_y(0), m_roi_width(0), m_roi_height(0), m_fps(0)
 {
 	RTC_LOG(INFO) << "RTSPVideoCapturer " << uri ;
 	if (opts.find("width") != opts.end()) {
 		m_width = std::stoi(opts.at("width"));
-	}	
+	}
 	if (opts.find("height") != opts.end()) {
 		m_height = std::stoi(opts.at("height"));
+	}
+	if (opts.find("roi_x") != opts.end()) {
+		m_roi_x = std::stoi(opts.at("roi_x"));
+	if (m_roi_x<0) {
+			RTC_LOG(LS_ERROR) << "Ignore roi_x=" << m_roi_x << ", it muss be >=0";
+			m_roi_x = 0;
+		}
 	}	
+	if (opts.find("roi_y") != opts.end()) {
+		m_roi_y = std::stoi(opts.at("roi_y"));
+		if (m_roi_y<0) {
+			RTC_LOG(LS_ERROR) << "Ignore roi_<=" << m_roi_y << ", it muss be >=0";
+			m_roi_y = 0;
+		}
+	}	
+	if (opts.find("roi_width") != opts.end()) {
+		m_roi_width = std::stoi(opts.at("roi_width"));
+		if (m_roi_width<=0) {
+			RTC_LOG(LS_ERROR) << "Ignore roi_width<=" << m_roi_width << ", it muss be >0";
+			m_roi_width = 0;
+		}
+	}	
+	if (opts.find("roi_height") != opts.end()) {
+		m_roi_height = std::stoi(opts.at("roi_height"));
+		if (m_roi_height<=0) {
+			RTC_LOG(LS_ERROR) << "Ignore roi_height<=" << m_roi_height << ", it muss be >0";
+			m_roi_height = 0;
+		}
+	}
 	if (opts.find("fps") != opts.end()) {
 		m_fps = std::stoi(opts.at("fps"));
-	}	
+	}
 	this->Start();
 }
 
@@ -200,7 +228,7 @@ bool RTSPVideoCapturer::onData(const char* id, unsigned char* buffer, ssize_t si
 			RTC_LOG(LS_ERROR) << "RTSPVideoCapturer:onData cannot JPEG dimension";
 			res = -1;
 		}
-			    
+
 	}
 
 	return (res == 0);
@@ -252,21 +280,55 @@ int32_t RTSPVideoCapturer::Decoded(webrtc::VideoFrame& decodedImage)
 	// rdp timestamp is just 32 bit, overflow error will occur each ~50 days
 	decodedImage.set_timestamp_us((int64_t)decodedImage.timestamp() * 1000);
 
+	if(m_roi_x >= decodedImage.width()) {
+		RTC_LOG(LS_ERROR) << "The ROI position protrudes beyond the right edge of the image. Ignore roi_x.";
+		m_roi_x = 0;
+	}
+	if(m_roi_y >= decodedImage.height()) {
+		RTC_LOG(LS_ERROR) << "The ROI position protrudes beyond the bottom edge of the image. Ignore roi_y.";
+		m_roi_y = 0;
+	}
+	if(m_roi_width != 0 && (m_roi_width + m_roi_x) > decodedImage.width()) {
+		RTC_LOG(LS_ERROR) << "The ROI protrudes beyond the right edge of the image. Ignore roi_width.";
+		m_roi_width = 0;
+	}
+	if(m_roi_height != 0 && (m_roi_height + m_roi_y) > decodedImage.height()) {
+		RTC_LOG(LS_ERROR) << "The ROI protrudes beyond the bottom edge of the image. Ignore roi_height.";
+		m_roi_height = 0;
+	}
+	
+	if(m_roi_width == 0) {
+		m_roi_width = decodedImage.width() - m_roi_x;
+	}
+	if(m_roi_height == 0) {
+		m_roi_height = decodedImage.height() - m_roi_y;
+	}
+
+	// source image is croped but destination image size is not set
+	if((m_roi_width != decodedImage.width() || m_roi_height != decodedImage.height()) && (m_height == 0 && m_width == 0)) {
+		m_height = m_roi_height;
+		m_width = m_roi_width;
+	}
+
 	if ( (m_height == 0) && (m_width == 0) ) {
 		broadcaster_.OnFrame(decodedImage);
 	} else {
 		int height = m_height;
 		int width = m_width;
 		if (height == 0) {
-			height = (decodedImage.height() * width) / decodedImage.width();
+			height = (m_roi_height * width) / m_roi_width;
 		}
 		else if (width == 0) {
-			width = (decodedImage.width() * height) / decodedImage.height();
+			width = (m_roi_width * height) / m_roi_height;
 		}
 		int stride_y = width;
 		int stride_uv = (width + 1) / 2;
 		rtc::scoped_refptr<webrtc::I420Buffer> scaled_buffer = webrtc::I420Buffer::Create(width, height, stride_y, stride_uv, stride_uv);
-		scaled_buffer->ScaleFrom(*decodedImage.video_frame_buffer()->ToI420());
+		if(m_roi_width != decodedImage.width() || m_roi_height != decodedImage.height()) {
+			scaled_buffer->CropAndScaleFrom(*decodedImage.video_frame_buffer()->ToI420(), m_roi_x, m_roi_y, m_roi_width, m_roi_height);
+		} else {
+			scaled_buffer->ScaleFrom(*decodedImage.video_frame_buffer()->ToI420());
+		}
 		webrtc::VideoFrame frame = webrtc::VideoFrame(scaled_buffer, decodedImage.timestamp(),
 			decodedImage.render_time_ms(), webrtc::kVideoRotation_0);
 				


### PR DESCRIPTION
## Description
1. New Memeber variables to define region of interest (ROI)
2. parse new Options to set the new variables
3. A few consistency checks with error messages
4. A few rules to allow omit options
5. Call CropAndScaleFrom(...) if necessary

If you prefer other variable names or an other way to set the variables I would  adapt the PR.

## Related Issue
#203

## Motivation and Context
Crop rtsp stream in webrtc-streamer

## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
