### PR TITLE
make tar extraction more Linux friendly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,13 +110,30 @@ target_link_libraries (${PROJECT_NAME} webrtcextra)
 # live555helper & live555
 if (NOT EXISTS live)
     file (DOWNLOAD http://www.live555.com/liveMedia/public/live555-latest.tar.gz ${CMAKE_SOURCE_DIR}/live555-latest.tar.gz )
+
     EXECUTE_PROCESS(
-        COMMAND 7z x live555-latest.tar.gz -so
-        COMMAND 7z x -aoa -ttar -si
-        RESULT_VARIABLE p7z_result
+        COMMAND tar --help
+        RESULT_VARIABLE use_tar
+        OUTPUT_QUIET
+        ERROR_QUIET
     )
-    if(NOT p7z_result STREQUAL "0")
-        message(FATAL_ERROR "Fetching and compiling live555 failed!")
+    if (use_tar STREQUAL "0")
+        message("Extract live555 with tar.")
+        EXECUTE_PROCESS(
+            COMMAND tar xzf live555-latest.tar.gz -so
+            RESULT_VARIABLE extract_result
+        )
+    else (use_tar STREQUAL "0")
+        message("Extract live555 with 7z.")
+        EXECUTE_PROCESS(
+            COMMAND 7z x live555-latest.tar.gz -so
+            COMMAND 7z x -aoa -ttar -si
+            RESULT_VARIABLE extract_result
+        )
+    endif (use_tar STREQUAL "0")
+
+    if(NOT extract_result STREQUAL "0")
+        message(FATAL_ERROR "Extraction of live555 failed!")
     endif()
 endif(NOT EXISTS live) 
 


### PR DESCRIPTION
Most people don't have 7z but tar will most likely be installed.

## Description

1. check if "tar" can be used
2. use "tar" if possible

## Motivation and Context
It should run with Linux

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
