### PR TITLE
Add function to conceal rtsp URLs in track labels

### DIFF
--- a/inc/PeerConnectionManager.h
+++ b/inc/PeerConnectionManager.h
@@ -22,7 +22,6 @@
 #include "rtc_base/strings/json.h"
 
 
-
 class PeerConnectionManager {
 	class VideoSink : public rtc::VideoSinkInterface<webrtc::VideoFrame> {
 		public:
@@ -271,7 +270,6 @@ class PeerConnectionManager {
 		void              setAnswer(const std::string &peerid, const Json::Value& jmessage);
 
 
-				
 	protected:
 		PeerConnectionObserver*                             CreatePeerConnection(const std::string& peerid);
 		bool                                                AddStreams(webrtc::PeerConnectionInterface* peer_connection, const std::string & videourl, const std::string & audiourl, const std::string & options);

--- a/inc/PeerConnectionManager.h
+++ b/inc/PeerConnectionManager.h
@@ -22,6 +22,7 @@
 #include "rtc_base/strings/json.h"
 
 
+
 class PeerConnectionManager {
 	class VideoSink : public rtc::VideoSinkInterface<webrtc::VideoFrame> {
 		public:
@@ -151,7 +152,8 @@ class PeerConnectionManager {
 			, m_peerid(peerid)
 			, m_localChannel(NULL)
 			, m_remoteChannel(NULL)
-			, iceCandidateList_(Json::arrayValue) {
+			, m_iceCandidateList(Json::arrayValue)
+			, m_deleting(false) {
 				RTC_LOG(INFO) << __FUNCTION__ << "CreatePeerConnection peerid:" << peerid;
 				m_pc = m_peerConnectionManager->peer_connection_factory_->CreatePeerConnection(config,
 							    NULL,
@@ -173,16 +175,14 @@ class PeerConnectionManager {
 				RTC_LOG(INFO) << __PRETTY_FUNCTION__;
 				delete m_localChannel;
 				delete m_remoteChannel;
-				// warning: pc->close call OnIceConnectionChange
-				// release m_pc to indicate this 
-				rtc::scoped_refptr<webrtc::PeerConnectionInterface> pc(m_pc);
-				m_pc.release();
-				if (pc.get()) {
-					pc->Close();
+				if (m_pc.get()) {
+					// warning: pc->close call OnIceConnectionChange
+					m_deleting = true;
+					m_pc->Close();
 				}
 			}
 
-			Json::Value getIceCandidateList() { return iceCandidateList_; 	}
+			Json::Value getIceCandidateList() { return m_iceCandidateList; }
 			
 			Json::Value getStats() {
 				m_statsCallback->clearReport();
@@ -206,7 +206,7 @@ class PeerConnectionManager {
 			}
 			virtual void OnRemoveStream(rtc::scoped_refptr<webrtc::MediaStreamInterface> stream) {
 				RTC_LOG(LERROR) << __PRETTY_FUNCTION__;
-				m_videosink.release();
+				m_videosink.reset();
 			}
 			virtual void OnDataChannel(rtc::scoped_refptr<webrtc::DataChannelInterface> channel) {
 				RTC_LOG(LERROR) << __PRETTY_FUNCTION__;
@@ -226,8 +226,8 @@ class PeerConnectionManager {
 				if ( (state == webrtc::PeerConnectionInterface::kIceConnectionFailed)
 				   ||(state == webrtc::PeerConnectionInterface::kIceConnectionClosed) )
 				{ 
-					iceCandidateList_.clear();
-					if (m_pc.get()) {
+					m_iceCandidateList.clear();
+					if (!m_deleting) {
 						std::thread([this]() {
 							m_peerConnectionManager->hangUp(m_peerid);
 						}).detach();
@@ -240,14 +240,15 @@ class PeerConnectionManager {
 
 
 		private:
-			PeerConnectionManager* m_peerConnectionManager;
-			const std::string m_peerid;
-			rtc::scoped_refptr<webrtc::PeerConnectionInterface> m_pc;
-			DataChannelObserver*    m_localChannel;
-			DataChannelObserver*    m_remoteChannel;
-			Json::Value iceCandidateList_;
+			PeerConnectionManager*                                   m_peerConnectionManager;
+			const std::string                                        m_peerid;
+			rtc::scoped_refptr<webrtc::PeerConnectionInterface>      m_pc;
+			DataChannelObserver*                                     m_localChannel;
+			DataChannelObserver*                                     m_remoteChannel;
+			Json::Value                                              m_iceCandidateList;
 			rtc::scoped_refptr<PeerConnectionStatsCollectorCallback> m_statsCallback;
 			std::unique_ptr<VideoSink>                               m_videosink;
+			bool                                                     m_deleting;
 	};
 
 	public:
@@ -270,24 +271,27 @@ class PeerConnectionManager {
 		void              setAnswer(const std::string &peerid, const Json::Value& jmessage);
 
 
+				
 	protected:
-		PeerConnectionObserver*                 CreatePeerConnection(const std::string& peerid);
-		bool                                    AddStreams(webrtc::PeerConnectionInterface* peer_connection, const std::string & videourl, const std::string & audiourl, const std::string & options);
-		rtc::scoped_refptr<webrtc::VideoTrackInterface> CreateVideoTrack(const std::string & videourl, const std::map<std::string,std::string> & opts);
-		rtc::scoped_refptr<webrtc::AudioTrackInterface> CreateAudioTrack(const std::string & audiourl, const std::map<std::string,std::string> & opts);
-		bool                                    streamStillUsed(const std::string & streamLabel);
-		const std::list<std::string>            getVideoCaptureDeviceList();
+		PeerConnectionObserver*                             CreatePeerConnection(const std::string& peerid);
+		bool                                                AddStreams(webrtc::PeerConnectionInterface* peer_connection, const std::string & videourl, const std::string & audiourl, const std::string & options);
+		rtc::scoped_refptr<webrtc::VideoTrackInterface>     CreateVideoTrack(const std::string & videourl, const std::map<std::string,std::string> & opts);
+		rtc::scoped_refptr<webrtc::AudioTrackInterface>     CreateAudioTrack(const std::string & audiourl, const std::map<std::string,std::string> & opts);
+		bool                                                streamStillUsed(const std::string & streamLabel);
+		const std::list<std::string>                        getVideoCaptureDeviceList();
 		rtc::scoped_refptr<webrtc::PeerConnectionInterface> getPeerConnection(const std::string& peerid);
+		const std::string                                   sanitizeLabel(const std::string &label);
 
 	protected:
+		typedef std::pair< rtc::scoped_refptr<webrtc::VideoTrackInterface>, rtc::scoped_refptr<webrtc::AudioTrackInterface>> AudioVideoPair;
 		rtc::scoped_refptr<webrtc::AudioDeviceModule>                             audioDeviceModule_;
 		rtc::scoped_refptr<webrtc::AudioDecoderFactory>                           audioDecoderfactory_;
 		rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface>                peer_connection_factory_;
-	    std::mutex                                                                m_peerMapMutex;
+		std::mutex                                                                m_peerMapMutex;
 		std::map<std::string, PeerConnectionObserver* >                           peer_connectionobs_map_;
-		std::map<std::string, std::pair< rtc::scoped_refptr<webrtc::VideoTrackInterface>, rtc::scoped_refptr<webrtc::AudioTrackInterface>> >  stream_map_;
-	    std::mutex                                                                m_streamMapMutex;
-		std::list<std::string>                                                              iceServerList_;
+		std::map<std::string, AudioVideoPair>                                     stream_map_;
+		std::mutex                                                                m_streamMapMutex;
+		std::list<std::string>                                                    iceServerList_;
 		const std::map<std::string,std::string>                                   m_urlVideoList;
 		const std::map<std::string,std::string>                                   m_urlAudioList;
 		std::map<std::string,std::string>                                         m_videoaudiomap;

--- a/src/PeerConnectionManager.cpp
+++ b/src/PeerConnectionManager.cpp
@@ -765,7 +765,6 @@ rtc::scoped_refptr<webrtc::VideoTrackInterface> PeerConnectionManager::CreateVid
 		video = videoit->second;
 	}
 
-
 	std::string label = this->sanitizeLabel(videourl + "_video");
 
 	rtc::scoped_refptr<webrtc::VideoTrackInterface> video_track;

--- a/src/PeerConnectionManager.cpp
+++ b/src/PeerConnectionManager.cpp
@@ -834,6 +834,7 @@ rtc::scoped_refptr<webrtc::AudioTrackInterface> PeerConnectionManager::CreateAud
 		RTC_LOG(LS_ERROR) << "Cannot create capturer audio:" << audiourl;
 	} else {
 		std::string label = this->sanitizeLabel(audiourl + "_audio");
+		audio_track = peer_connection_factory_->CreateAudioTrack(label, audioSource);
 	}
 	
 	return audio_track;


### PR DESCRIPTION
## Description

This change removes potentially sensitive rtsp URLs from being visible by the viewer. Currently labels are used to describe audio and video tracks. These can be stream names, device names, or rtsp urls. 

Hiding the full rtsp url is done by hashing the entire string. 


## Motivation and Context

rtsp urls can contain sensitive password information, in the form of:
rtsp://user:pass@domain/path


## Types of changes

One function was added to the PeerConnectionManager.h and PeerConnectionManager.cpp and that function is used when a label is created. 

The include <functional> was added to access the std::hash function. 

