### PR TITLE
Improve example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,12 @@ A short sample HTML page using webrtc-streamer running locally on port 8000 :
 	<script src="libs/adapter.min.js" ></script>
 	<script src="webrtcstreamer.js" ></script>
 	<script>        
-	    var webRtcServer      = new WebRtcStreamer("video",location.protocol+"//"+window.location.hostname+":8000");
-	    window.onload         = function() { webRtcServer.connect("rtsp://pi2.local:8554/unicast") }
-	    window.onbeforeunload = function() { webRtcServer.disconnect() }
+	    var webRtcServer      = null;
+	    window.onload         = function() { 
+	        webRtcServer      = new WebRtcStreamer("video",location.protocol+"//"+window.location.hostname+":8000");
+		webRtcServer.connect("rtsp://pi2.local:8554/unicast");
+	    }
+	    window.onbeforeunload = function() { webRtcServer.disconnect(); }
 	</script>
 	</head>
 	<body> 


### PR DESCRIPTION
## Description

This example is not longer running (at least not in my configuration) in current versions of chrome/chromium because the object with id="video" is below the JS part due to this this.videoElement = document.getElementById(videoElement) = undefined.

## Motivation and Context

Stream does not start due to JS Errors because this.videoElement = undefined

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
