### PR TITLE
Fixing the calculation of the audio decoded buffer size in case of stereo and high sampling rate

### DIFF
--- a/src/rtspaudiocapturer.cpp
+++ b/src/rtspaudiocapturer.cpp
@@ -48,9 +48,9 @@ bool RTSPAudioSource::onNewSession(const char* id, const char* media, const char
 		
 		// parse sdp to extract freq and channel
 		std::string fmt(sdp);
-	        std::transform(fmt.begin(), fmt.end(), fmt.begin(), [](unsigned char c){ return std::tolower(c); });
+		std::transform(fmt.begin(), fmt.end(), fmt.begin(), [](unsigned char c){ return std::tolower(c); });
 		std::string codecstr(codec);
-	        std::transform(codecstr.begin(), codecstr.end(), codecstr.begin(), [](unsigned char c){ return std::tolower(c); });
+		std::transform(codecstr.begin(), codecstr.end(), codecstr.begin(), [](unsigned char c){ return std::tolower(c); });
 		size_t pos = fmt.find(codecstr);
 		if (pos != std::string::npos) {
 			fmt.erase(0, pos+strlen(codec));
@@ -92,11 +92,7 @@ bool RTSPAudioSource::onData(const char* id, unsigned char* buffer, ssize_t size
 	bool success = false;
 	int segmentLength = m_freq/100;
 	if (m_decoder.get() != NULL) {
-		int maxDecodedBufferSize = size*sizeof(int16_t);
-		if (m_channel == 2)
-		{
-			maxDecodedBufferSize = (segmentLength * m_channel)*(m_channel*sizeof(int16_t));
-		}
+		int maxDecodedBufferSize = m_decoder->PacketDuration(buffer, size)*m_channel*sizeof(int16_t);
 		int16_t* decoded = new int16_t[maxDecodedBufferSize];
 		webrtc::AudioDecoder::SpeechType speech_type;
 		int decodedBufferSize = m_decoder->Decode(buffer, size, m_freq, maxDecodedBufferSize, decoded, &speech_type);

--- a/src/rtspaudiocapturer.cpp
+++ b/src/rtspaudiocapturer.cpp
@@ -69,7 +69,7 @@ bool RTSPAudioSource::onNewSession(const char* id, const char* media, const char
 				m_channel = std::stoi(channel);
 			}
 		}
-		RTC_LOG(INFO) << "RTSPAudioSource::onNewSession code:"<< codecstr << " freq:" << m_freq << " channel:" << m_channel;
+		RTC_LOG(INFO) << "RTSPAudioSource::onNewSession codec:"<< codecstr << " freq:" << m_freq << " channel:" << m_channel;
 		std::map<std::string, std::string> params;
 		if (m_channel == 2)
 		{


### PR DESCRIPTION
## Description

Fixing the calculation of the audio decoded buffer size in case of stereo and high sampling rate

## Related Issue

https://github.com/mpromonet/webrtc-streamer/issues/17

## Motivation and Context

I managed to fix the issue with Opus, it's working great with mono and stereo.

- In `webrtc::SdpAudioFormat` - the 'stereo' parameter is needed and needs to be set to "1".

- The function m_decoder->Decode returns the size of the decoded buffer size. The size includes the channels of the stereo so there's no need to multiply the returned size with the number of channels. 

- The decoded buffer and max_decoded_bytes are too small, I added a robust buffer size calculation for stereo and higher sampling rates.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ X ] Bug fix (non-breaking change which fixes an issue)
