### PR TITLE
Add docker-compose commands to start app

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,11 @@ You can expose V4L2 devices from your host using :
 
         docker run --device=/dev/video0 -p 8000:8000 -it mpromonet/webrtc-streamer
 
+Alternatively you can start the application via docker-compose:
+
+        docker-compose up app
+        docker-compose up app-v4l2
+
 The container entry point is the webrtc-streamer application, then you can :
 
 * get the help using :

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,15 @@ services:
     build: .
     ports:
      - "8000:8000"
+  app:
+    container_name: webrtc-streamer
+    image: mpromonet/webrtc-streamer:latest
+    ports:
+      - "8000:8000/tcp"
+  app-v4l2:
+    container_name: webrtc-streamer-v4l2
+    image: mpromonet/webrtc-streamer:latest
+    ports:
+      - "8000:8000/tcp"
+    devices:
+      - "/dev/video0:/dev/video0"


### PR DESCRIPTION
## Description

It is hard to stop the docker container when running the command manually with `docker run...`
which means you manually need find the container and stop it. By using docker-compose it will facilitate to start stop and using the correct settings. 

## Related Issue
#299 

## Motivation and Context

Makes it easier to start the app via docker. No need to master docker commands, just docker-compose up the app!


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
