### PR TITLE
Add port range for webRTC UDP port

### DIFF
--- a/inc/PeerConnectionManager.h
+++ b/inc/PeerConnectionManager.h
@@ -154,7 +154,7 @@ class PeerConnectionManager {
 
 	class PeerConnectionObserver : public webrtc::PeerConnectionObserver {
 		public:
-			PeerConnectionObserver(PeerConnectionManager* peerConnectionManager, const std::string& peerid, const webrtc::PeerConnectionInterface::RTCConfiguration & config)
+			PeerConnectionObserver(PeerConnectionManager* peerConnectionManager, const std::string& peerid, const webrtc::PeerConnectionInterface::RTCConfiguration & config, std::unique_ptr<cricket::PortAllocator> portAllocator)
 			: m_peerConnectionManager(peerConnectionManager)
 			, m_peerid(peerid)
 			, m_localChannel(NULL)
@@ -163,7 +163,7 @@ class PeerConnectionManager {
 			, m_deleting(false) {
 				RTC_LOG(INFO) << __FUNCTION__ << "CreatePeerConnection peerid:" << peerid;
 				m_pc = m_peerConnectionManager->m_peer_connection_factory->CreatePeerConnection(config,
-							    NULL,
+					std::move(portAllocator),
 							    NULL,
 							    this);
 				
@@ -259,7 +259,7 @@ class PeerConnectionManager {
 	};
 
 	public:
-		PeerConnectionManager(const std::list<std::string> & iceServerList, const Json::Value & config, const webrtc::AudioDeviceModule::AudioLayer audioLayer, const std::string& publishFilter);
+		PeerConnectionManager(const std::list<std::string> & iceServerList, const Json::Value & config, const webrtc::AudioDeviceModule::AudioLayer audioLayer, const std::string& publishFilter, const std::string& webrtcUdpPortRange);
 		virtual ~PeerConnectionManager();
 
 		bool InitializePeerConnection();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,8 @@ int main(int argc, char* argv[])
 	const char* defaultlocalturnurl  = "turn:turn@0.0.0.0:3478";
 	const char* localturnurl  = NULL;
 	const char* stunurl       = "stun.l.google.com:19302";
+	std::string defaultWebrtcUdpPortRange = "0:65535";
+	std::string localWebrtcUdpPortRange = "";
 	int logLevel              = rtc::LERROR;
 	const char* webroot       = "./html";
 	std::string sslCertificate;
@@ -68,7 +70,7 @@ int main(int argc, char* argv[])
 	httpAddress.append(httpPort);
 
 	int c = 0;
-	while ((c = getopt (argc, argv, "hVv::" "c:H:w:N:A:D:C:" "T::t:S::s::" "a::q:" "n:u:U:")) != -1)
+	while ((c = getopt (argc, argv, "hVv::" "c:H:w:N:A:D:C:" "T::t:S::s::" "a::q:" "n:u:U:" "R:")) != -1)
 	{
 		switch (c)
 		{
@@ -117,6 +119,11 @@ int main(int argc, char* argv[])
 				std::cout << VERSION << std::endl;
 				exit(0);
 			break;
+			case 'R':
+				std::cout << " First log " << std::endl;
+				localWebrtcUdpPortRange = optarg ? optarg : defaultWebrtcUdpPortRange;
+				std::cout << localWebrtcUdpPortRange << " [-R defaultWebrtcUdpPortRange]" << std::endl;
+				break;
 			case 'h':
 			default:
 				std::cout << argv[0] << " [-H http port] [-S[embeded stun address]] [-t [username:password@]turn_address] -[v[v]]  [url1]...[urln]" << std::endl;
@@ -143,6 +150,7 @@ int main(int argc, char* argv[])
 				std::cout << "\t -n name -u videourl -U audiourl    : register a stream with name using url"                         << std::endl;			
 				std::cout << "\t [url]                              : url to register in the source list"                                         << std::endl;
 				std::cout << "\t -C config.json                     : load urls from JSON config file"                                                 << std::endl;
+				std::cout << "\t -R [Udp port range min:max]        : Set the webrtc udp port range (default 0:65534)
 			
 				exit(0);
 		}
@@ -176,7 +184,7 @@ int main(int argc, char* argv[])
 		iceServerList.push_back(std::string("turn:")+turnurl);
 	}
 
-	webRtcServer = new PeerConnectionManager(iceServerList, config["urls"], audioLayer, publishFilter);
+	webRtcServer = new PeerConnectionManager(iceServerList, config["urls"], audioLayer, publishFilter, localWebrtcUdpPortRange);
 	if (!webRtcServer->InitializePeerConnection())
 	{
 		std::cout << "Cannot Initialize WebRTC server" << std::endl;
@@ -257,7 +265,7 @@ int main(int argc, char* argv[])
 					tcp_server_socket->Bind(server_addr);
 					tcp_server_socket->Listen(5);
 					turnserver->AddInternalServerSocket(tcp_server_socket, cricket::PROTO_TCP);
-				}			
+				}
 
 				is.str(turnurl);
 				is.clear();


### PR DESCRIPTION
## Description
Hi Michel,
I have implement an interface to set the webrtc udp port range by a new option -RminPort:maxPort
It's works fine on my server debian 9 who's relay the rtsp stream and send it on my browser.

## Related Issue
https://github.com/mpromonet/webrtc-streamer/issues/306


## Motivation and Context


## Types of changes
A add a webrtcUdpPortRange struct on PeerConnectionManager, and the setter of this struct.
The PeerConnectionObserver implement  a basicPortAllocator object for setting port range.

I'm happy to contribute to your really nice project.
Thank's for your streamer.

