### PR TITLE
fix #475: allow to limit peerconnecion number

### DIFF
--- a/inc/PeerConnectionManager.h
+++ b/inc/PeerConnectionManager.h
@@ -202,7 +202,8 @@ class PeerConnectionManager {
 			, m_localChannel(NULL)
 			, m_remoteChannel(NULL)
 			, m_iceCandidateList(Json::arrayValue)
-			, m_deleting(false) {
+			, m_deleting(false)
+			, m_creationTime(rtc::TimeMicros()) {
 
 				RTC_LOG(LS_INFO) << __FUNCTION__ << "CreatePeerConnection peerid:" << peerid;
 				webrtc::PeerConnectionDependencies dependencies(this);
@@ -299,6 +300,8 @@ class PeerConnectionManager {
 			virtual void OnIceGatheringChange(webrtc::PeerConnectionInterface::IceGatheringState) {
 			}
 
+			uint64_t    getCreationTime() { return m_creationTime; }
+			std::string getPeerId() { return m_peerid; }
 
 		private:
 			PeerConnectionManager*                                   m_peerConnectionManager;
@@ -311,10 +314,12 @@ class PeerConnectionManager {
 			std::unique_ptr<VideoSink>                               m_videosink;
 			std::unique_ptr<AudioSink>                               m_audiosink;
 			bool                                                     m_deleting;
+			uint64_t                                                 m_creationTime;
+
 	};
 
 	public:
-		PeerConnectionManager(const std::list<std::string> & iceServerList, const Json::Value & config, webrtc::AudioDeviceModule::AudioLayer audioLayer, const std::string& publishFilter, const std::string& webrtcUdpPortRange, bool useNullCodec = true, bool usePlanB = true);
+		PeerConnectionManager(const std::list<std::string> & iceServerList, const Json::Value & config, webrtc::AudioDeviceModule::AudioLayer audioLayer, const std::string& publishFilter, const std::string& webrtcUdpPortRange, bool useNullCodec = true, bool usePlanB = true, int maxpc = 0);
 		virtual ~PeerConnectionManager();
 
 		bool InitializePeerConnection();
@@ -345,6 +350,7 @@ class PeerConnectionManager {
 		const std::string                                     sanitizeLabel(const std::string &label);
 		void                                                  createAudioModule(webrtc::AudioDeviceModule::AudioLayer audioLayer);
 		std::unique_ptr<webrtc::SessionDescriptionInterface>  getAnswer(const std::string & peerid, webrtc::SessionDescriptionInterface *session_description, const std::string & videourl, const std::string & audiourl, const std::string & options);
+		std::string                                           getOldestPeerCannection();
 
 
 	protected:
@@ -369,5 +375,6 @@ class PeerConnectionManager {
 		std::string																  m_webrtcPortRange;
 		bool                                                                      m_useNullCodec;
 		bool                                                                      m_usePlanB;
+		int                                                                       m_maxpc;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,7 @@ int main(int argc, char* argv[])
 	Json::Value config;  
 	bool        useNullCodec = false;
 	bool        usePlanB = false;
+	int         maxpc = 0;
 	std::string webrtcTrialsFields = "WebRTC-FrameDropper/Disabled/";
 
 	std::string httpAddress("0.0.0.0:");
@@ -76,7 +77,7 @@ int main(int argc, char* argv[])
 
 	std::string streamName;
 	int c = 0;
-	while ((c = getopt (argc, argv, "hVv::C:" "c:H:w:N:A:D:X" "T::t:S::s::R:W:" "a::q:ob" "n:u:U:")) != -1)
+	while ((c = getopt (argc, argv, "hVv::C:" "c:H:w:N:A:D:Xm:" "T::t:S::s::R:W:" "a::q:ob" "n:u:U:")) != -1)
 	{
 		switch (c)
 		{
@@ -87,6 +88,7 @@ int main(int argc, char* argv[])
 			case 'A': passwdFile = optarg;         break;
 			case 'D': authDomain = optarg;         break;
 			case 'X': disableXframeOptions = true; break;
+			case 'm': maxpc = atoi(optarg);        break;
 
 			case 'T': localturnurl = optarg ? optarg : defaultlocalturnurl; turnurl = localturnurl; break;
 			case 't': turnurl = optarg;                                                             break;
@@ -199,7 +201,7 @@ int main(int argc, char* argv[])
 	// init trials fields
 	webrtc::field_trial::InitFieldTrialsFromString(webrtcTrialsFields.c_str());
 
-	webRtcServer = new PeerConnectionManager(iceServerList, config["urls"], audioLayer, publishFilter, localWebrtcUdpPortRange, useNullCodec, usePlanB);
+	webRtcServer = new PeerConnectionManager(iceServerList, config["urls"], audioLayer, publishFilter, localWebrtcUdpPortRange, useNullCodec, usePlanB, maxpc);
 	if (!webRtcServer->InitializePeerConnection())
 	{
 		std::cout << "Cannot Initialize WebRTC server" << std::endl;


### PR DESCRIPTION
## Description

Add an option to limit the number of active peer connection.
When reached, oldest peer connection is closed.

## Related Issue

https://github.com/mpromonet/webrtc-streamer/issues/475
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
