### PR TITLE
docs(readme): refactor, cleanup, & styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-	<a href="https://wiki.friendlyelec.com/wiki/index.php/NanoPi_NEO_Air"><img src="images/nanopi.jpg" width="500"></a>
+	<a href="https://wiki.friendlyelec.com/wiki/index.php/NanoPi_NEO_Air"><img alt="A picture of a Nano PI NEO Air, a small device with a camera. The camera is pointing towards the viewer." src="images/nanopi.jpg" width="500"></a>
 	<h1>WebRTC-Streamer</h1>
 </div>
 
@@ -27,16 +27,16 @@
 ## Installation
 
 If you don't want to [compile it yourself](#build), you can download the
-artifacts off of: [CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer),
+artifacts off of [CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer),
 [CirrusCI](https://cirrus-ci.com/github/mpromonet/webrtc-streamer), or
-[GitHub CI](https://github.com/mpromonet/webrtc-streamer/actions):
+[GitHub CI](https://github.com/mpromonet/webrtc-streamer/actions), for the following architectures:
 
-- for x86_64 on Ubuntu Bionic
-- for armv7 crosscompiled (this build is running on Raspberry Pi2 and NanoPi
+- x86_64 on Ubuntu Bionic
+- armv7 crosscompiled (this build is running on Raspberry Pi2 and NanoPi
   NEO)
-- for armv6+vfp crosscompiled (this build is running on Raspberry PiB and should
+- armv6+vfp crosscompiled (this build is running on Raspberry PiB and should
   run on a Raspberry Zero)
-- for arm64 crosscompiled
+- arm64 crosscompiled
 - Windows x64 build with clang
 - MacOS
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 <div align="center">
 
-[![CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer.svg?style=shield)](https://circleci.com/gh/mpromonet/webrtc-streamer)
-[![CirusCI](https://api.cirrus-ci.com/github/mpromonet/webrtc-streamer.svg)](https://cirrus-ci.com/github/mpromonet/webrtc-streamer)
+[![CircleCI](https://img.shields.io/circleci/build/github/mpromonet/webrtc-streamer?label=circleci&logo=circleci)](https://circleci.com/gh/mpromonet/webrtc-streamer)
+[![CirusCI](https://img.shields.io/cirrus/github/mpromonet/webrtc-streamer?label=cirrusci&logo=cirrusci)](https://cirrus-ci.com/github/mpromonet/webrtc-streamer)
 [![Snap Status](https://snapcraft.io//webrtc-streamer/badge.svg)](https://snapcraft.io/webrtc-streamer)
 
-[![GithubCI](https://github.com/mpromonet/webrtc-streamer/workflows/C/C++%20CI%20linux/badge.svg)](https://github.com/mpromonet/webrtc-streamer/actions/workflows/cpp-linux.yml)
-[![GithubCI](https://github.com/mpromonet/webrtc-streamer/workflows/C/C++%20CI%20windows/badge.svg)](https://github.com/mpromonet/webrtc-streamer/actions/workflows/cpp-windows.yml)
-[![GithubCI](https://github.com/mpromonet/webrtc-streamer/workflows/C/C++%20CI%20macos/badge.svg)](https://github.com/mpromonet/webrtc-streamer/actions/workflows/cpp-macos.yml)
+[![GithubCI](https://img.shields.io/github/actions/workflow/status/mpromonet/webrtc-streamer/cpp-linux.yml?label=C%2FC%2B%2B%20ci%20linux&logo=github)](https://github.com/mpromonet/webrtc-streamer/actions/workflows/cpp-linux.yml)
+[![GithubCI](https://img.shields.io/github/actions/workflow/status/mpromonet/webrtc-streamer/cpp-windows.yml?label=C%2FC%2B%2B%20ci%20windows&logo=github)](https://github.com/mpromonet/webrtc-streamer/actions/workflows/cpp-windows.yml)
+[![GithubCI](https://img.shields.io/github/actions/workflow/status/mpromonet/webrtc-streamer/cpp-macos.yml?label=C%2FC%2B%2B%20ci%20macos&logo=github)](https://github.com/mpromonet/webrtc-streamer/actions/workflows/cpp-macos.yml)
 
 [![Release](https://img.shields.io/github/release/mpromonet/webrtc-streamer.svg)](https://github.com/mpromonet/webrtc-streamer/releases/latest)
 [![Download](https://img.shields.io/github/downloads/mpromonet/webrtc-streamer/total.svg)](https://github.com/mpromonet/webrtc-streamer/releases/latest)
@@ -20,22 +20,23 @@
 [![Demo](https://img.shields.io/badge/heroku-demo-blue)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/mpromonet/webrtc-streamer)
 
-**An experimental, straight-forward abstraction over WebRTC to stream various media sources.**
+**An experimental, straight-forward abstraction over WebRTC to stream various
+media sources.**
 
 </div>
 
 ## Installation
 
-If you don't want to [compile it yourself](#build), you can download the
+If you don't want to [compile it yourself](#manual-build), you can download the
 artifacts off of [CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer),
 [CirrusCI](https://cirrus-ci.com/github/mpromonet/webrtc-streamer), or
-[GitHub CI](https://github.com/mpromonet/webrtc-streamer/actions), for the following architectures:
+[GitHub CI](https://github.com/mpromonet/webrtc-streamer/actions), for the
+following architectures:
 
 - x86_64 on Ubuntu Bionic
-- armv7 crosscompiled (this build is running on Raspberry Pi2 and NanoPi
-  NEO)
-- armv6+vfp crosscompiled (this build is running on Raspberry PiB and should
-  run on a Raspberry Zero)
+- armv7 crosscompiled (this build is running on Raspberry Pi2 and NanoPi NEO)
+- armv6+vfp crosscompiled (this build is running on Raspberry PiB and should run
+  on a Raspberry Zero)
 - arm64 crosscompiled
 - Windows x64 build with clang
 - MacOS
@@ -61,8 +62,8 @@ artifacts off of [CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer),
 
 	-S[stun_address]                   : start embeded STUN server bind to address (default 0.0.0.0:3478)
 	-s[stun_address]                   : use an external STUN server (default:stun.l.google.com:19302 , -:means no STUN)
-	-t[username:password@]turn_address : use an external TURN relay server (default:disabled)
 	-T[username:password@]turn_address : start embeded TURN server (default:disabled)
+	-t[username:password@]turn_address : use an external TURN relay server (default:disabled)
 	-R [Udp port range min:max]        : Set the webrtc udp port range (default 0:65535)
 	-W webrtc_trials_fields            : Set the webrtc trials fields (default:WebRTC-FrameDropper/Disabled/)		
 	-a[audio layer]                    : spefify audio capture layer to use (default:0)		
@@ -100,20 +101,20 @@ The list of HTTP API endpoints is available by GETting `/api/help`.
 
 Options for the WebRTC stream name:
 
-- an alias defined using -n argument then the corresponding -u argument will be
+- an alias defined using `-n` argument then the corresponding `-u` argument will be
   used to create the capturer
 - an "rtsp://" url that will be opened using an RTSP capturer based on live555
 - an "file://" url that will be opened using an MKV capturer based on live555
 - an "screen://" url that will be opened by
-  webrtc::DesktopCapturer::CreateScreenCapturer
+  `webrtc::DesktopCapturer::CreateScreenCapturer`
 - an "window://" url that will be opened by
-  webrtc::DesktopCapturer::CreateWindowCapturer
-- an "v4l2://" url that will capture H264 frames and store it using
-  webrtc::VideoFrameBuffer::Type::kNative type (obviously not supported on
+  `webrtc::DesktopCapturer::CreateWindowCapturer`
+- an "v4l2://" url that will capture [H264](https://en.wikipedia.org/wiki/Advanced_Video_Coding) frames and store it using
+  webrtc::VideoFrameBuffer::Type::kNative type (not supported on
   Windows)
 - a capture device name
 
-## Build
+## Manual Build
 
 ### Dependencies
 
@@ -123,30 +124,32 @@ This package depends on the following packages:
 - [civetweb HTTP server](https://github.com/civetweb/civetweb) for HTTP server
 - [live555](http://www.live555.com/liveMedia) for RTSP/MKV source
 
-The following steps are required to build the project, and will install the dependencies above:
+The following steps are required to build the project, and will install the
+dependencies above:
 
-- Install the Chromium depot tools (for WebRTC - contains a variety of tools
-  that helps external WebRTC development).
-  ```sh
-  pushd ..
-  git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-  export PATH=$PATH:`realpath depot_tools`
-  popd
-  ```
-- Download WebRTC
+1. Install the Chromium depot tools (for WebRTC - contains a variety of tools
+   that helps external WebRTC development).
 
-  ```sh
-  mkdir ../webrtc
-  pushd ../webrtc
-  fetch --no-history webrtc 
-  popd
-  ```
+   ```sh
+   pushd ..
+   git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+   export PATH=$PATH:`realpath depot_tools`
+   popd
+   ```
+2. Download WebRTC
 
-- Build WebRTC Streamer
+   ```sh
+   mkdir ../webrtc
+   pushd ../webrtc
+   fetch --no-history webrtc 
+   popd
+   ```
 
-  ```sh
-  cmake . && make
-  ```
+3. Build WebRTC Streamer
+
+   ```sh
+   cmake . && make
+   ```
 
 It is possible to specify cmake parameters `WEBRTCROOT` &
 `WEBRTCDESKTOPCAPTURE`:
@@ -168,18 +171,22 @@ We can access to the WebRTC stream using
 [webrtcstreamer.html](https://github.com/mpromonet/webrtc-streamer-html/blob/master/webrtcstreamer.html).
 For instance:
 
-- https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtcstreamer.html?rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
-- https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtcstreamer.html?Bunny
+- [webrtcstreamer.html?rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtcstreamer.html?rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov)
+- [webrtcstreamer.html?Bunny](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtcstreamer.html?Bunny)
+
+---
 
 An example displaying grid of WebRTC Streams is available using option
 `layout=<lines>x<columns>`
 [![Screenshot](images/layout2x4.png)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/?layout=2x4)
 
-[Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/?layout=2x4)
+[Live Demo (?layout=2x4)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/?layout=2x4)
 
 ## Using embedded STUN/TURN server behind a NAT
 
-It is possible to start embeded ICE server and publish its URL using:
+It is possible to start an embeded [STUN](https://en.wikipedia.org/wiki/STUN)
+and [TURN](https://en.wikipedia.org/wiki/Traversal_Using_Relays_around_NAT)
+server and publish its URL:
 
 ```sh
 ./webrtc-streamer -S0.0.0.0:3478 -s$(curl -s ifconfig.me):3478
@@ -201,7 +208,7 @@ upnpc -r 8000 tcp 3478 tcp 3478 udp
 
 Adapting with the HTTP port, STUN port, TURN port.
 
-## Embed in a HTML page
+## HTML Embedding
 
 Instead of using the internal HTTP server, it is easy to display a WebRTC stream
 in a HTML page served by another HTTP server. The URL of the WebRTC-streamer to
@@ -210,7 +217,7 @@ use should be given creating the
 instance:
 
 ```js
-var webRtcServer      = new WebRtcStreamer(<video tag>, <webrtc-streamer url>);
+var webRtcServer = new WebRtcStreamer(<video tag>, <webrtc-streamer url>);
 ```
 
 A short sample HTML page using webrtc-streamer running locally on port 8000:
@@ -235,9 +242,10 @@ A short sample HTML page using webrtc-streamer running locally on port 8000:
 </html>
 ```
 
-## Using WebComponent
+## Using WebComponents
 
-[Web Components](https://www.webcomponents.org/) are an alternative way to
+WebRTC-streamer provides its own
+[Web Components](https://www.webcomponents.org/) as an alternative way to
 display a WebRTC stream in an HTML page. For example:
 
 ```html
@@ -366,17 +374,21 @@ docker run --device=/dev/video0 -p 8000:8000 -it mpromonet/webrtc-streamer
 
 The container entry point is the webrtc-streamer application, then you can:
 
-- get the help using:
+- view all commands
   ```sh
-  docker run -p 8000:8000 -it mpromonet/webrtc-streamer -h
+  docker run -p 8000:8000 -it mpromonet/webrtc-streamer --help
   ```
-- run the container registering a RTSP url using:
+- run the container registering a RTSP url:
 
   ```sh
   docker run -p 8000:8000 -it mpromonet/webrtc-streamer -n raspicam -u rtsp://pi2.local:8554/unicast
   ```
-- run the container giving config.json file using:
+- run the container giving config.json file:
 
   ```sh
   docker run -p 8000:8000 -v $PWD/config.json:/app/config.json mpromonet/webrtc-streamer
   ```
+
+## License
+
+Distributed under the UNLICENSE license. See [`LICENSE`](./LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 <div align="center">
 	<a href="https://wiki.friendlyelec.com/wiki/index.php/NanoPi_NEO_Air"><img alt="A picture of a Nano PI NEO Air, a small device with a camera. The camera is pointing towards the viewer." src="images/nanopi.jpg" width="500"></a>
-	<h1>WebRTC-Streamer</h1>
-</div>
 
-<div align="center">
-
+# WebRTC-Streamer
 [![CircleCI](https://img.shields.io/circleci/build/github/mpromonet/webrtc-streamer?label=circleci&logo=circleci)](https://circleci.com/gh/mpromonet/webrtc-streamer)
 [![CirusCI](https://img.shields.io/cirrus/github/mpromonet/webrtc-streamer?label=cirrusci&logo=cirrusci)](https://cirrus-ci.com/github/mpromonet/webrtc-streamer)
 [![Snap Status](https://snapcraft.io//webrtc-streamer/badge.svg)](https://snapcraft.io/webrtc-streamer)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
+<div align="center">
+	<a href="http://wiki.friendlyarm.com/wiki/index.php/NanoPi_NEO_Air"><img src="images/nanopi.jpg" width="500"></a>
+	<h1>WebRTC-Streamer</h1>
+</div>
+
+<div align="center">
+
 [![CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer.svg?style=shield)](https://circleci.com/gh/mpromonet/webrtc-streamer)
 [![CirusCI](https://api.cirrus-ci.com/github/mpromonet/webrtc-streamer.svg)](https://cirrus-ci.com/github/mpromonet/webrtc-streamer)
 [![Snap Status](https://snapcraft.io//webrtc-streamer/badge.svg)](https://snapcraft.io/webrtc-streamer)
+
 [![GithubCI](https://github.com/mpromonet/webrtc-streamer/workflows/C/C++%20CI%20linux/badge.svg)](https://github.com/mpromonet/webrtc-streamer/actions/workflows/cpp-linux.yml)
 [![GithubCI](https://github.com/mpromonet/webrtc-streamer/workflows/C/C++%20CI%20windows/badge.svg)](https://github.com/mpromonet/webrtc-streamer/actions/workflows/cpp-windows.yml)
 [![GithubCI](https://github.com/mpromonet/webrtc-streamer/workflows/C/C++%20CI%20macos/badge.svg)](https://github.com/mpromonet/webrtc-streamer/actions/workflows/cpp-macos.yml)
@@ -12,46 +20,11 @@
 [![Demo](https://img.shields.io/badge/heroku-demo-blue)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/mpromonet/webrtc-streamer)
 
-# WebRTC-streamer
+**An experimental, straight-forward abstraction over WebRTC to stream various media sources.**
 
-[![NanoPi](images/nanopi.jpg)](http://wiki.friendlyarm.com/wiki/index.php/NanoPi_NEO_Air)
+</div>
 
-## Overview
-
-WebRTC-streamer is an experiment to stream various sources (such as v4l2
-streams, rstp streams, or file streams) through WebRTC using simple mechanisms.
-
-It embeds a HTTP server that implements an API and serves a simple HTML page
-that use them through AJAX.
-
-WebRTC-streamer implements
-[WebRTC signaling](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling)
-through HTTP requests:
-
-- `/api/call` - send offer and get answer
-- `/api/hangup` - close a call
-
-- `/api/addIceCandidate` - add a candidate
-- `/api/getIceCandidate` - get the list of candidates
-
-The list of HTTP API is available using /api/help.
-
-The webrtc stream name could be:
-
-- an alias defined using -n argument then the corresponding -u argument will be
-  used to create the capturer
-- an "rtsp://" url that will be openned using an RTSP capturer based on live555
-- an "file://" url that will be openned using an MKV capturer based on live555
-- an "screen://" url that will be openned by
-  webrtc::DesktopCapturer::CreateScreenCapturer
-- an "window://" url that will be openned by
-  webrtc::DesktopCapturer::CreateWindowCapturer
-- an "v4l2://" url that will capture H264 frames and store it using
-  webrtc::VideoFrameBuffer::Type::kNative type (obviously not supported on
-  Windows)
-- a capture device name
-
-## Artifacts
+## Installation
 
 If you don't want to [compile it yourself](#build), you can download the
 artifacts off of: [CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer),
@@ -67,50 +40,11 @@ artifacts off of: [CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer),
 - Windows x64 build with clang
 - MacOS
 
-## Dependencies
-
-This package depends on the following packages:
-
-- [WebRTC Native Code Package](http://www.webrtc.org) for WebRTC
-- [civetweb HTTP server](https://github.com/civetweb/civetweb) for HTTP server
-- [live555](http://www.live555.com/liveMedia) for RTSP/MKV source
-
-## Build
-
-- Install the Chromium depot tools (for WebRTC - contains a variety of tools
-  that helps external WebRTC development).
-  ```sh
-  pushd ..
-  git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-  export PATH=$PATH:`realpath depot_tools`
-  popd
-  ```
-- Download WebRTC
-
-  ```sh
-  mkdir ../webrtc
-  pushd ../webrtc
-  fetch --no-history webrtc 
-  popd
-  ```
-
-- Build WebRTC Streamer
-
-  ```sh
-  cmake . && make
-  ```
-
-It is possible to specify cmake parameters `WEBRTCROOT` &
-`WEBRTCDESKTOPCAPTURE`:
-
-- `$WEBRTCROOT/src` should contains source (default is $(pwd)/../webrtc)
-- `WEBRTCDESKTOPCAPTURE` enabling desktop capture if available (default is ON)
-
 ## Usage
 
-```
-./webrtc-streamer [-H http port] [-S[embeded stun address]] -[v[v]]  [url1]...[urln]
-./webrtc-streamer [-H http port] [-s[external stun address]] -[v[v]] [url1]...[urln]
+```roff
+./webrtc-streamer [-H http port] [-S[embeded stun address]] -[v[v]]  [urls...]
+./webrtc-streamer [-H http port] [-s[external stun address]] -[v[v]] [urls...]
 ./webrtc-streamer -V
 	-v[v[v]]           : verbosity
 	-V                 : print version
@@ -147,7 +81,80 @@ Using `-o` allows storing compressed frame data from the backend stream using
 to forward H264 frames from V4L2 device or RTSP stream to WebRTC stream. It use
 less CPU and has less adaptation (resize, codec, bandwidth are disabled).
 
-Examples
+## API
+
+It embeds a HTTP server that implements an API and serves a simple HTML page
+that uses the endpoints through AJAX calls.
+
+WebRTC-streamer implements
+[WebRTC signaling](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling)
+through HTTP requests:
+
+- `/api/call` - send offer and get answer
+- `/api/hangup` - close a call
+
+- `/api/addIceCandidate` - add a candidate
+- `/api/getIceCandidate` - get the list of candidates
+
+The list of HTTP API endpoints is available by GETting `/api/help`.
+
+Options for the WebRTC stream name:
+
+- an alias defined using -n argument then the corresponding -u argument will be
+  used to create the capturer
+- an "rtsp://" url that will be opened using an RTSP capturer based on live555
+- an "file://" url that will be opened using an MKV capturer based on live555
+- an "screen://" url that will be opened by
+  webrtc::DesktopCapturer::CreateScreenCapturer
+- an "window://" url that will be opened by
+  webrtc::DesktopCapturer::CreateWindowCapturer
+- an "v4l2://" url that will capture H264 frames and store it using
+  webrtc::VideoFrameBuffer::Type::kNative type (obviously not supported on
+  Windows)
+- a capture device name
+
+## Build
+
+### Dependencies
+
+This package depends on the following packages:
+
+- [WebRTC Native Code Package](http://www.webrtc.org) for WebRTC
+- [civetweb HTTP server](https://github.com/civetweb/civetweb) for HTTP server
+- [live555](http://www.live555.com/liveMedia) for RTSP/MKV source
+
+The following steps are required to build the project, and will install the dependencies above:
+
+- Install the Chromium depot tools (for WebRTC - contains a variety of tools
+  that helps external WebRTC development).
+  ```sh
+  pushd ..
+  git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+  export PATH=$PATH:`realpath depot_tools`
+  popd
+  ```
+- Download WebRTC
+
+  ```sh
+  mkdir ../webrtc
+  pushd ../webrtc
+  fetch --no-history webrtc 
+  popd
+  ```
+
+- Build WebRTC Streamer
+
+  ```sh
+  cmake . && make
+  ```
+
+It is possible to specify cmake parameters `WEBRTCROOT` &
+`WEBRTCDESKTOPCAPTURE`:
+
+- `$WEBRTCROOT/src` should contains source (default is $(pwd)/../webrtc)
+- `WEBRTCDESKTOPCAPTURE` enabling desktop capture if available (default is ON)
+
+## Examples
 
 ```sh
 ./webrtc-streamer rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
@@ -197,7 +204,7 @@ Adapting with the HTTP port, STUN port, TURN port.
 ## Embed in a HTML page
 
 Instead of using the internal HTTP server, it is easy to display a WebRTC stream
-in a HTML page served by another HTTP server. The URL of the webrtc-streamer to
+in a HTML page served by another HTTP server. The URL of the WebRTC-streamer to
 use should be given creating the
 [WebRtcStreamer](http://htmlpreview.github.io/?https://github.com/mpromonet/webrtc-streamer-html/blob/master/jsdoc/WebRtcStreamer.html)
 instance:
@@ -228,7 +235,7 @@ A short sample HTML page using webrtc-streamer running locally on port 8000:
 </html>
 ```
 
-# Using WebComponent
+## Using WebComponent
 
 [Web Components](https://www.webcomponents.org/) are an alternative way to
 display a WebRTC stream in an HTML page. For example:
@@ -343,7 +350,7 @@ A short sample to publish WebRTC streams to a Jitsi Video Room could be:
 
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/xmppvideoroom.html)
 
-# Docker Image
+## Docker Image
 
 You can start the application using the docker image:
 

--- a/README.md
+++ b/README.md
@@ -5,35 +5,32 @@
 [![GithubCI](https://github.com/mpromonet/webrtc-streamer/workflows/C/C++%20CI%20windows/badge.svg)](https://github.com/mpromonet/webrtc-streamer/actions/workflows/cpp-windows.yml)
 [![GithubCI](https://github.com/mpromonet/webrtc-streamer/workflows/C/C++%20CI%20macos/badge.svg)](https://github.com/mpromonet/webrtc-streamer/actions/workflows/cpp-macos.yml)
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/c209c81a15854964a08df5c300f56804)](https://www.codacy.com/app/michelpromonet_2643/webrtc-streamer?utm_source=github.com&utm_medium=referral&utm_content=mpromonet/webrtc-streamer&utm_campaign=badger)
-
 [![Release](https://img.shields.io/github/release/mpromonet/webrtc-streamer.svg)](https://github.com/mpromonet/webrtc-streamer/releases/latest)
 [![Download](https://img.shields.io/github/downloads/mpromonet/webrtc-streamer/total.svg)](https://github.com/mpromonet/webrtc-streamer/releases/latest)
 [![Docker Pulls](https://img.shields.io/docker/pulls/mpromonet/webrtc-streamer.svg)](https://hub.docker.com/r/mpromonet/webrtc-streamer/)
 
-[![Demo](https://heroku-badge.herokuapp.com/?app=webrtc-streamer)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/)
+[![Demo](https://img.shields.io/badge/heroku-demo-blue)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/mpromonet/webrtc-streamer)
 
-WebRTC-streamer
-===============
+# WebRTC-streamer
 
 [![NanoPi](images/nanopi.jpg)](http://wiki.friendlyarm.com/wiki/index.php/NanoPi_NEO_Air)
 
-WebRTC-streamer is an experiment to stream video capture devices and RTSP sources through WebRTC using simple mechanism.  
+WebRTC-streamer is an experiment to stream various sources (such as v4l2 streams, rstp streams, or file streams) through WebRTC using simple mechanisms.  
 
-It embeds a HTTP server that implements API and serves a simple HTML page that use them through AJAX.   
+It embeds a HTTP server that implements an API and serves a simple HTML page that use them through AJAX.   
 
 The WebRTC signaling is implemented through HTTP requests:
 
- - /api/call   : send offer and get answer
- - /api/hangup : close a call
+ - `/api/call` - send offer and get answer
+ - `/api/hangup` - close a call
 
- - /api/addIceCandidate : add a candidate
- - /api/getIceCandidate : get the list of candidates
+ - `/api/addIceCandidate` - add a candidate
+ - `/api/getIceCandidate` - get the list of candidates
 
 The list of HTTP API is available using /api/help.
 
-Nowdays there is builds on [CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer), [CirrusCI](https://cirrus-ci.com/github/mpromonet/webrtc-streamer) and [GitHub CI](https://github.com/mpromonet/webrtc-streamer/actions) :
+Nowdays there is builds on [CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer), [CirrusCI](https://cirrus-ci.com/github/mpromonet/webrtc-streamer) and [GitHub CI](https://github.com/mpromonet/webrtc-streamer/actions):
  * for x86_64 on Ubuntu Bionic
  * for armv7 crosscompiled (this build is running on Raspberry Pi2 and NanoPi NEO)
  * for armv6+vfp crosscompiled (this build is running on Raspberry PiB and should run on a Raspberry Zero)
@@ -41,7 +38,7 @@ Nowdays there is builds on [CircleCI](https://circleci.com/gh/mpromonet/webrtc-s
  * Windows x64 build with clang
  * MacOS
  
-The webrtc stream name could be :
+The webrtc stream name could be:
  * an alias defined using -n argument then the corresponding -u argument will be used to create the capturer
  * an "rtsp://" url that will be openned using an RTSP capturer based on live555
  * an "file://" url that will be openned using an MKV capturer based on live555
@@ -50,65 +47,70 @@ The webrtc stream name could be :
  * an "v4l2://" url that will capture H264 frames and store it using webrtc::VideoFrameBuffer::Type::kNative type (obviously not supported on Windows)
  * a capture device name
 
-Dependencies :
--------------
-It is based on :
+## Dependencies
+
+It is based on:
  * [WebRTC Native Code Package](http://www.webrtc.org) for WebRTC
  * [civetweb HTTP server](https://github.com/civetweb/civetweb) for HTTP server
  * [live555](http://www.live555.com/liveMedia) for RTSP/MKV source
 
-Build
-===============
+## Build
 Install the Chromium depot tools (for WebRTC).
--------
-	pushd ..
-	git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-	export PATH=$PATH:`realpath depot_tools`
-	popd
+
+```sh
+pushd ..
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+export PATH=$PATH:`realpath depot_tools`
+popd
+```
 
 Download WebRTC 
--------
-	mkdir ../webrtc
-	pushd ../webrtc
-	fetch --no-history webrtc 
-	popd
+```sh
+mkdir ../webrtc
+pushd ../webrtc
+fetch --no-history webrtc 
+popd
+```
 	
 
 Build WebRTC Streamer
--------
-	cmake . && make 
+```sh
+cmake . && make
+```
 
-It is possible to specify cmake parameters WEBRTCROOT & WEBRTCDESKTOPCAPTURE :
- - $WEBRTCROOT/src should contains source (default is $(pwd)/../webrtc) 
- - WEBRTCDESKTOPCAPTURE enabling desktop capture if available (default is ON) 
+It is possible to specify cmake parameters `WEBRTCROOT` & `WEBRTCDESKTOPCAPTURE`:
+ - `$WEBRTCROOT/src` should contains source (default is $(pwd)/../webrtc) 
+ - `WEBRTCDESKTOPCAPTURE` enabling desktop capture if available (default is ON) 
 
-Usage
-===============
-	./webrtc-streamer [-H http port] [-S[embeded stun address]] -[v[v]]  [url1]...[urln]
-	./webrtc-streamer [-H http port] [-s[external stun address]] -[v[v]] [url1]...[urln]
-	./webrtc-streamer -V
-		-v[v[v]]           : verbosity
-		-V                 : print version
-		-C config.json                     : load urls from JSON config file 
-		-n name -u videourl -U audiourl    : register a name for a video url and an audio url
-		[url]                              : url to register in the source list
+## Usage
 
-		-H [hostname:]port : HTTP server binding (default 0.0.0.0:8000)
-		-w webroot         : path to get files
-		-c sslkeycert      : path to private key and certificate for HTTPS
-		-N nbthreads       : number of threads for HTTP server
-		-A passwd          : password file for HTTP server access
-		-D authDomain      : authentication domain for HTTP server access (default:mydomain.com)
+```
+./webrtc-streamer [-H http port] [-S[embeded stun address]] -[v[v]]  [url1]...[urln]
+./webrtc-streamer [-H http port] [-s[external stun address]] -[v[v]] [url1]...[urln]
+./webrtc-streamer -V
+	-v[v[v]]           : verbosity
+	-V                 : print version
+	-C config.json                     : load urls from JSON config file 
+	-n name -u videourl -U audiourl    : register a name for a video url and an audio url
+	[url]                              : url to register in the source list
 
-		-S[stun_address]                   : start embeded STUN server bind to address (default 0.0.0.0:3478)
-		-s[stun_address]                   : use an external STUN server (default:stun.l.google.com:19302 , -:means no STUN)
-		-t[username:password@]turn_address : use an external TURN relay server (default:disabled)
-		-T[username:password@]turn_address : start embeded TURN server (default:disabled)
-		-R [Udp port range min:max]        : Set the webrtc udp port range (default 0:65535)
-		-W webrtc_trials_fields            : Set the webrtc trials fields (default:WebRTC-FrameDropper/Disabled/)		
-		-a[audio layer]                    : spefify audio capture layer to use (default:0)		
-		-q[filter]                         : spefify publish filter (default:.*)
-		-o                                 : use null codec (keep frame encoded)
+	-H [hostname:]port : HTTP server binding (default 0.0.0.0:8000)
+	-w webroot         : path to get files
+	-c sslkeycert      : path to private key and certificate for HTTPS
+	-N nbthreads       : number of threads for HTTP server
+	-A passwd          : password file for HTTP server access
+	-D authDomain      : authentication domain for HTTP server access (default:mydomain.com)
+
+	-S[stun_address]                   : start embeded STUN server bind to address (default 0.0.0.0:3478)
+	-s[stun_address]                   : use an external STUN server (default:stun.l.google.com:19302 , -:means no STUN)
+	-t[username:password@]turn_address : use an external TURN relay server (default:disabled)
+	-T[username:password@]turn_address : start embeded TURN server (default:disabled)
+	-R [Udp port range min:max]        : Set the webrtc udp port range (default 0:65535)
+	-W webrtc_trials_fields            : Set the webrtc trials fields (default:WebRTC-FrameDropper/Disabled/)		
+	-a[audio layer]                    : spefify audio capture layer to use (default:0)		
+	-q[filter]                         : spefify publish filter (default:.*)
+	-o                                 : use null codec (keep frame encoded)
+```
  
 
 Arguments of '-H' are forwarded to option [listening_ports](https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md#listening_ports-8080) of civetweb, then it is possible to use the civetweb syntax like `-H8000,9000` or `-H8080r,8443s`.
@@ -116,118 +118,129 @@ Arguments of '-H' are forwarded to option [listening_ports](https://github.com/c
 Using `-o` allow to store compressed frame from backend stream using `webrtc::VideoFrameBuffer::Type::kNative`. This Hack the stucture `webrtc::VideoFrameBuffer` storing data in a override of i420 buffer. This allow to forward H264 frames from V4L2 device or RTSP stream to WebRTC stream. It use less CPU and have less adaptation (resize, codec, bandwidth are disabled).
 
 Examples
------
-	./webrtc-streamer rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
+
+```sh
+./webrtc-streamer rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
+```
 
 
 [![Screenshot](images/snapshot.png)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/)
 
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/)
 
-We can access to the WebRTC stream using [webrtcstreamer.html](https://github.com/mpromonet/webrtc-streamer-html/blob/master/webrtcstreamer.html) for instance :
+We can access to the WebRTC stream using [webrtcstreamer.html](https://github.com/mpromonet/webrtc-streamer-html/blob/master/webrtcstreamer.html). For instance:
 
- * https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtcstreamer.html?rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
- * https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtcstreamer.html?Bunny
+* https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtcstreamer.html?rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
+* https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtcstreamer.html?Bunny
 
 An example displaying grid of WebRTC Streams is available using option "layout=<lines>x<columns>"
 [![Screenshot](images/layout2x4.png)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/?layout=2x4)
 
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/?layout=2x4)
 
-Using embedded STUN/TURN server behind a NAT:
-===============
+## Using embedded STUN/TURN server behind a NAT
 
-It is possible start embeded ICE server and publish its url using:
+It is possible to start embeded ICE server and publish its url using:
 
-    ./webrtc-streamer -S0.0.0.0:3478 -s$(curl -s ifconfig.me):3478
-    ./webrtc-streamer -s- -T0.0.0.0:3478 -tturn:turn@$(curl -s ifconfig.me):3478
-    ./webrtc-streamer -S0.0.0.0:3478 -s$(curl -s ifconfig.me):3478 -T0.0.0.0:3479 -tturn:turn@$(curl -s ifconfig.me):3479
+```sh
+./webrtc-streamer -S0.0.0.0:3478 -s$(curl -s ifconfig.me):3478
+./webrtc-streamer -s- -T0.0.0.0:3478 -tturn:turn@$(curl -s ifconfig.me):3478
+./webrtc-streamer -S0.0.0.0:3478 -s$(curl -s ifconfig.me):3478 -T0.0.0.0:3479 -tturn:turn@$(curl -s ifconfig.me):3479
+```
+
 The command `curl -s ifconfig.me` is getting the public IP, it could also given as a static parameter.
 
 In order to configure the NAT rules using the upnp feature of the router, it is possible to use [upnpc](https://manpages.debian.org/unstable/miniupnpc/upnpc.1.en.html) like this:
 
-    upnpc -r 8000 tcp 3478 tcp 3478 udp
+```sh
+upnpc -r 8000 tcp 3478 tcp 3478 udp
+```
 Adapting with the HTTP port, STUN port, TURN port.
 
-Embed in a HTML page:
-===============
-Instead of using the internal HTTP server, it is easy to display a WebRTC stream in a HTML page served by another HTTP server. The URL of the webrtc-streamer to use should be given creating the [WebRtcStreamer](http://htmlpreview.github.io/?https://github.com/mpromonet/webrtc-streamer-html/blob/master/jsdoc/WebRtcStreamer.html) instance :
+## Embed in a HTML page
+Instead of using the internal HTTP server, it is easy to display a WebRTC stream in a HTML page served by another HTTP server. The URL of the webrtc-streamer to use should be given creating the [WebRtcStreamer](http://htmlpreview.github.io/?https://github.com/mpromonet/webrtc-streamer-html/blob/master/jsdoc/WebRtcStreamer.html) instance:
 
-	var webRtcServer      = new WebRtcStreamer(<video tag>, <webrtc-streamer url>);
+```js
+var webRtcServer      = new WebRtcStreamer(<video tag>, <webrtc-streamer url>);
+```
 
-A short sample HTML page using webrtc-streamer running locally on port 8000 :
+A short sample HTML page using webrtc-streamer running locally on port 8000:
 
-	<html>
-	<head>
-	<script src="libs/adapter.min.js" ></script>
-	<script src="webrtcstreamer.js" ></script>
-	<script>        
-	    var webRtcServer      = null;
-	    window.onload         = function() { 
-	        webRtcServer      = new WebRtcStreamer("video",location.protocol+"//"+window.location.hostname+":8000");
-	        webRtcServer.connect("rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov");
-	    }
-	    window.onbeforeunload = function() { webRtcServer.disconnect(); }
-	</script>
-	</head>
-	<body> 
-	    <video id="video" />
-	</body>
-	</html>
+```html
+<html>
+<head>
+<script src="libs/adapter.min.js" ></script>
+<script src="webrtcstreamer.js" ></script>
+<script>        
+	var webRtcServer      = null;
+	window.onload         = function() { 
+		webRtcServer      = new WebRtcStreamer("video",location.protocol+"//"+window.location.hostname+":8000");
+		webRtcServer.connect("rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov");
+	}
+	window.onbeforeunload = function() { webRtcServer.disconnect(); }
+</script>
+</head>
+<body> 
+	<video id="video" />
+</body>
+</html>
+```
 
-Using WebComponent
-==================
-Using web-component could be a simple way to display some webrtc stream, a minimal page could be :
+# Using WebComponent
+Using web-component could be a simple way to display some webrtc stream, a minimal page could be:
 
-	<html>
-	<head>
-        <script type="module" src="webrtc-streamer-element.js"></script>
-	</head>
-	<body>
-	   <webrtc-streamer url="rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov"></webrtc-streamer>
-	</body>
-	</html>
-
+```html
+<html>
+<head>
+	<script type="module" src="webrtc-streamer-element.js"></script>
+</head>
+<body>
+	<webrtc-streamer url="rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov"></webrtc-streamer>
+</body>
+</html>
+```
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/Bunny.html)  
 
-Using the webcomponent with a stream selector :
+Using the webcomponent with a stream selector:
 
 [![Screenshot](images/wc-selector.jpg)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtc-streamer-element.html)
 
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtc-streamer-element.html)
 
-Using the webcomponent over google map :
+Using the webcomponent over google map:
 
 [![Screenshot](images/wc-map.jpg)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/map.html)
 
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/map.html)
 
-Object detection using tensorflow.js
-===============
+## Object detection using tensorflow.js
 
 [![Screenshot](images/tensorflow.jpg)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/tensorflow.html)
 
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/tensorflow.html)
 
 
-Connect to Janus Gateway Video Room
-===============
+## Connect to Janus Gateway Video Room
 A simple way to publish WebRTC stream to a [Janus Gateway](https://janus.conf.meetecho.com) Video Room is to use the [JanusVideoRoom](http://htmlpreview.github.io/?https://github.com/mpromonet/webrtc-streamer-html/blob/master/jsdoc/JanusVideoRoom.html) interface
 
-        var janus = new JanusVideoRoom(<janus url>, <webrtc-streamer url>)
+```js
+var janus = new JanusVideoRoom(<janus url>, <webrtc-streamer url>)
+```
 
-A short sample to publish WebRTC streams to Janus Video Room could be :
+A short sample to publish WebRTC streams to Janus Video Room could be:
 
-	<html>
-	<head>
-	<script src="janusvideoroom.js" ></script>
-	<script>        
-		var janus = new JanusVideoRoom("https://janus.conf.meetecho.com/janus", null);
-		janus.join(1234, "rtsp://pi2.local:8554/unicast","pi2");
-		janus.join(1234, "rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov","media");	    
-	</script>
-	</head>
-	</html>
+```html
+<html>
+<head>
+<script src="janusvideoroom.js" ></script>
+<script>        
+	var janus = new JanusVideoRoom("https://janus.conf.meetecho.com/janus", null);
+	janus.join(1234, "rtsp://pi2.local:8554/unicast","pi2");
+	janus.join(1234, "rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov","media");	    
+</script>
+</head>
+</html>
+```
 
 [![Screenshot](images/janusvideoroom.png)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/janusvideoroom.html)
 
@@ -235,61 +248,73 @@ A short sample to publish WebRTC streams to Janus Video Room could be :
 
 This way the communication between [Janus API](https://janus.conf.meetecho.com/docs/JS.html) and [WebRTC Streamer API](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/help) is implemented in Javascript running in browser.
 
-The same logic could be implemented in NodeJS using the same JS API :
+The same logic could be implemented in NodeJS using the same JS API:
 
-	global.request = require('then-request');
-	var JanusVideoRoom = require('./html/janusvideoroom.js'); 
-	var janus = new JanusVideoRoom("http://192.168.0.15:8088/janus", "http://192.168.0.15:8000")
-	janus.join(1234,"mmal service 16.1","video")
+```js
+global.request = require('then-request');
+var JanusVideoRoom = require('./html/janusvideoroom.js'); 
+var janus = new JanusVideoRoom("http://192.168.0.15:8088/janus", "http://192.168.0.15:8000")
+janus.join(1234,"mmal service 16.1","video")
+```
 
-Connect to Jitsi 
-===============
+## Connect to Jitsi
+
 A simple way to publish WebRTC stream to a [Jitsi](https://meet.jit.si) Video Room is to use the [XMPPVideoRoom](http://htmlpreview.github.io/?https://github.com/mpromonet/webrtc-streamer-html/blob/master/jsdoc/XMPPVideoRoom.html) interface
 
-        var xmpp = new XMPPVideoRoom(<xmpp server url>, <webrtc-streamer url>)
+```js
+var xmpp = new XMPPVideoRoom(<xmpp server url>, <webrtc-streamer url>)
+```
 
-A short sample to publish WebRTC streams to a Jitsi Video Room could be :
+A short sample to publish WebRTC streams to a Jitsi Video Room could be:
 
-	<html>
-	<head>
-	<script src="libs/strophe.min.js" ></script>
-	<script src="libs/strophe.muc.min.js" ></script>
-	<script src="libs/strophe.disco.min.js" ></script>
-	<script src="libs/strophe.jingle.sdp.js"></script>
-	<script src="libs/jquery-3.5.1.min.js"></script>
-	<script src="xmppvideoroom.js" ></script>
-	<script>        
-		var xmpp = new XMPPVideoRoom("meet.jit.si", null);
-		xmpp.join("testroom", "rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov","Bunny");	    
-	</script>
-	</head>
-	</html>
+```html
+<html>
+<head>
+<script src="libs/strophe.min.js" ></script>
+<script src="libs/strophe.muc.min.js" ></script>
+<script src="libs/strophe.disco.min.js" ></script>
+<script src="libs/strophe.jingle.sdp.js"></script>
+<script src="libs/jquery-3.5.1.min.js"></script>
+<script src="xmppvideoroom.js" ></script>
+<script>        
+	var xmpp = new XMPPVideoRoom("meet.jit.si", null);
+	xmpp.join("testroom", "rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov","Bunny");	    
+</script>
+</head>
+</html>
+```
 
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/xmppvideoroom.html)
 
-Docker image
-===============
-You can start the application using the docker image :
+# Docker Image
+You can start the application using the docker image:
 
-        docker run -p 8000:8000 -it mpromonet/webrtc-streamer
+```sh
+docker run -p 8000:8000 -it mpromonet/webrtc-streamer
+```
 
-You can expose V4L2 devices from your host using :
+You can expose V4L2 devices from your host using:
 
-        docker run --device=/dev/video0 -p 8000:8000 -it mpromonet/webrtc-streamer
+```sh
+docker run --device=/dev/video0 -p 8000:8000 -it mpromonet/webrtc-streamer
+```
 
-The container entry point is the webrtc-streamer application, then you can :
+The container entry point is the webrtc-streamer application, then you can:
 
-* get the help using :
+* get the help using:
+	```sh
+	docker run -p 8000:8000 -it mpromonet/webrtc-streamer -h
+	```
+* run the container registering a RTSP url using:
 
-        docker run -p 8000:8000 -it mpromonet/webrtc-streamer -h
+	```sh
+    docker run -p 8000:8000 -it mpromonet/webrtc-streamer -n raspicam -u rtsp://pi2.local:8554/unicast
+	```
+* run the container giving config.json file using:
 
-* run the container registering a RTSP url using :
-
-        docker run -p 8000:8000 -it mpromonet/webrtc-streamer -n raspicam -u rtsp://pi2.local:8554/unicast
-
-* run the container giving config.json file using :
-
-        docker run -p 8000:8000 -v $PWD/config.json:/app/config.json mpromonet/webrtc-streamer
+	```sh
+    docker run -p 8000:8000 -v $PWD/config.json:/app/config.json mpromonet/webrtc-streamer
+	```
 
 
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,17 @@
 
 [![NanoPi](images/nanopi.jpg)](http://wiki.friendlyarm.com/wiki/index.php/NanoPi_NEO_Air)
 
+## Overview
+
 WebRTC-streamer is an experiment to stream various sources (such as v4l2
 streams, rstp streams, or file streams) through WebRTC using simple mechanisms.
 
 It embeds a HTTP server that implements an API and serves a simple HTML page
 that use them through AJAX.
 
-The WebRTC signaling is implemented through HTTP requests:
+WebRTC-streamer implements
+[WebRTC signaling](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Signaling_and_video_calling)
+through HTTP requests:
 
 - `/api/call` - send offer and get answer
 - `/api/hangup` - close a call
@@ -31,20 +35,6 @@ The WebRTC signaling is implemented through HTTP requests:
 - `/api/getIceCandidate` - get the list of candidates
 
 The list of HTTP API is available using /api/help.
-
-Nowdays there is builds on
-[CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer),
-[CirrusCI](https://cirrus-ci.com/github/mpromonet/webrtc-streamer) and
-[GitHub CI](https://github.com/mpromonet/webrtc-streamer/actions):
-
-- for x86_64 on Ubuntu Bionic
-- for armv7 crosscompiled (this build is running on Raspberry Pi2 and NanoPi
-  NEO)
-- for armv6+vfp crosscompiled (this build is running on Raspberry PiB and should
-  run on a Raspberry Zero)
-- for arm64 crosscompiled
-- Windows x64 build with clang
-- MacOS
 
 The webrtc stream name could be:
 
@@ -61,9 +51,25 @@ The webrtc stream name could be:
   Windows)
 - a capture device name
 
+## Artifacts
+
+If you don't want to [compile it yourself](#build), you can download the
+artifacts off of: [CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer),
+[CirrusCI](https://cirrus-ci.com/github/mpromonet/webrtc-streamer), or
+[GitHub CI](https://github.com/mpromonet/webrtc-streamer/actions):
+
+- for x86_64 on Ubuntu Bionic
+- for armv7 crosscompiled (this build is running on Raspberry Pi2 and NanoPi
+  NEO)
+- for armv6+vfp crosscompiled (this build is running on Raspberry PiB and should
+  run on a Raspberry Zero)
+- for arm64 crosscompiled
+- Windows x64 build with clang
+- MacOS
+
 ## Dependencies
 
-It is based on:
+This package depends on the following packages:
 
 - [WebRTC Native Code Package](http://www.webrtc.org) for WebRTC
 - [civetweb HTTP server](https://github.com/civetweb/civetweb) for HTTP server
@@ -71,29 +77,28 @@ It is based on:
 
 ## Build
 
-Install the Chromium depot tools (for WebRTC).
+- Install the Chromium depot tools (for WebRTC - contains a variety of tools
+  that helps external WebRTC development).
+  ```sh
+  pushd ..
+  git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+  export PATH=$PATH:`realpath depot_tools`
+  popd
+  ```
+- Download WebRTC
 
-```sh
-pushd ..
-git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-export PATH=$PATH:`realpath depot_tools`
-popd
-```
+  ```sh
+  mkdir ../webrtc
+  pushd ../webrtc
+  fetch --no-history webrtc 
+  popd
+  ```
 
-Download WebRTC
+- Build WebRTC Streamer
 
-```sh
-mkdir ../webrtc
-pushd ../webrtc
-fetch --no-history webrtc 
-popd
-```
-
-Build WebRTC Streamer
-
-```sh
-cmake . && make
-```
+  ```sh
+  cmake . && make
+  ```
 
 It is possible to specify cmake parameters `WEBRTCROOT` &
 `WEBRTCDESKTOPCAPTURE`:
@@ -136,11 +141,11 @@ Arguments of '-H' are forwarded to option
 of civetweb, then it is possible to use the civetweb syntax like `-H8000,9000`
 or `-H8080r,8443s`.
 
-Using `-o` allow to store compressed frame from backend stream using
+Using `-o` allows storing compressed frame data from the backend stream using
 `webrtc::VideoFrameBuffer::Type::kNative`. This Hack the stucture
 `webrtc::VideoFrameBuffer` storing data in a override of i420 buffer. This allow
 to forward H264 frames from V4L2 device or RTSP stream to WebRTC stream. It use
-less CPU and have less adaptation (resize, codec, bandwidth are disabled).
+less CPU and has less adaptation (resize, codec, bandwidth are disabled).
 
 Examples
 
@@ -160,14 +165,14 @@ For instance:
 - https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtcstreamer.html?Bunny
 
 An example displaying grid of WebRTC Streams is available using option
-"layout=<lines>x<columns>"
+`layout=<lines>x<columns>`
 [![Screenshot](images/layout2x4.png)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/?layout=2x4)
 
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/?layout=2x4)
 
 ## Using embedded STUN/TURN server behind a NAT
 
-It is possible to start embeded ICE server and publish its url using:
+It is possible to start embeded ICE server and publish its URL using:
 
 ```sh
 ./webrtc-streamer -S0.0.0.0:3478 -s$(curl -s ifconfig.me):3478
@@ -225,8 +230,8 @@ A short sample HTML page using webrtc-streamer running locally on port 8000:
 
 # Using WebComponent
 
-Using web-component could be a simple way to display some webrtc stream, a
-minimal page could be:
+[Web Components](https://www.webcomponents.org/) are an alternative way to
+display a WebRTC stream in an HTML page. For example:
 
 ```html
 <html>

--- a/README.md
+++ b/README.md
@@ -72,17 +72,18 @@ following architectures:
 ```
 
 Arguments of '-H' are forwarded to option
-[listening_ports](https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md#listening_ports-8080)
-of civetweb, then it is possible to use the civetweb syntax like `-H8000,9000`
-or `-H8080r,8443s`.
+[`listening_ports`](https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md#listening_ports-8080)
+of civetweb, allowing use of the civetweb syntax like `-H8000,9000` or
+`-H8080r,8443s`.
 
 Using `-o` allows storing compressed frame data from the backend stream using
-`webrtc::VideoFrameBuffer::Type::kNative`. This Hack the stucture
-`webrtc::VideoFrameBuffer` storing data in a override of i420 buffer. This allow
-to forward H264 frames from V4L2 device or RTSP stream to WebRTC stream. It use
-less CPU and has less adaptation (resize, codec, bandwidth are disabled).
+`webrtc::VideoFrameBuffer::Type::kNative`. This hacks the stucture
+`webrtc::VideoFrameBuffer` storing data in a override of the i420 buffer. This
+allows forwarding H264 frames from V4L2 device or RTSP stream to WebRTC stream.
+It uses less CPU, but has less features (resize, codec, and bandwidth are
+disabled).
 
-## API
+## HTTP API
 
 It embeds a HTTP server that implements an API and serves a simple HTML page
 that uses the endpoints through AJAX calls.
@@ -101,16 +102,17 @@ The list of HTTP API endpoints is available by GETting `/api/help`.
 
 Options for the WebRTC stream name:
 
-- an alias defined using `-n` argument then the corresponding `-u` argument will be
-  used to create the capturer
+- an alias defined using `-n` argument then the corresponding `-u` argument will
+  be used to create the capturer
 - an "rtsp://" url that will be opened using an RTSP capturer based on live555
 - an "file://" url that will be opened using an MKV capturer based on live555
 - an "screen://" url that will be opened by
   `webrtc::DesktopCapturer::CreateScreenCapturer`
 - an "window://" url that will be opened by
   `webrtc::DesktopCapturer::CreateWindowCapturer`
-- an "v4l2://" url that will capture [H264](https://en.wikipedia.org/wiki/Advanced_Video_Coding) frames and store it using
-  webrtc::VideoFrameBuffer::Type::kNative type (not supported on
+- an "v4l2://" url that will capture
+  [H264](https://en.wikipedia.org/wiki/Advanced_Video_Coding) frames and store
+  it using webrtc::VideoFrameBuffer::Type::kNative type (not supported on
   Windows)
 - a capture device name
 
@@ -391,4 +393,5 @@ The container entry point is the webrtc-streamer application, then you can:
 
 ## License
 
-Distributed under the UNLICENSE license. See [`LICENSE`](./LICENSE) for more information.
+Distributed under the UNLICENSE license. See [`LICENSE`](./LICENSE) for more
+information.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Download](https://img.shields.io/github/downloads/mpromonet/webrtc-streamer/total.svg)](https://github.com/mpromonet/webrtc-streamer/releases/latest)
 [![Docker Pulls](https://img.shields.io/docker/pulls/mpromonet/webrtc-streamer.svg)](https://hub.docker.com/r/mpromonet/webrtc-streamer/)
 
-[![Demo](https://img.shields.io/badge/heroku-demo-blue)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/)
+[![Demo](https://img.shields.io/badge/azure-demo-blue)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/mpromonet/webrtc-streamer)
 
 **An experimental, straight-forward abstraction over WebRTC to stream various

--- a/README.md
+++ b/README.md
@@ -16,45 +16,61 @@
 
 [![NanoPi](images/nanopi.jpg)](http://wiki.friendlyarm.com/wiki/index.php/NanoPi_NEO_Air)
 
-WebRTC-streamer is an experiment to stream various sources (such as v4l2 streams, rstp streams, or file streams) through WebRTC using simple mechanisms.  
+WebRTC-streamer is an experiment to stream various sources (such as v4l2
+streams, rstp streams, or file streams) through WebRTC using simple mechanisms.
 
-It embeds a HTTP server that implements an API and serves a simple HTML page that use them through AJAX.   
+It embeds a HTTP server that implements an API and serves a simple HTML page
+that use them through AJAX.
 
 The WebRTC signaling is implemented through HTTP requests:
 
- - `/api/call` - send offer and get answer
- - `/api/hangup` - close a call
+- `/api/call` - send offer and get answer
+- `/api/hangup` - close a call
 
- - `/api/addIceCandidate` - add a candidate
- - `/api/getIceCandidate` - get the list of candidates
+- `/api/addIceCandidate` - add a candidate
+- `/api/getIceCandidate` - get the list of candidates
 
 The list of HTTP API is available using /api/help.
 
-Nowdays there is builds on [CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer), [CirrusCI](https://cirrus-ci.com/github/mpromonet/webrtc-streamer) and [GitHub CI](https://github.com/mpromonet/webrtc-streamer/actions):
- * for x86_64 on Ubuntu Bionic
- * for armv7 crosscompiled (this build is running on Raspberry Pi2 and NanoPi NEO)
- * for armv6+vfp crosscompiled (this build is running on Raspberry PiB and should run on a Raspberry Zero)
- * for arm64 crosscompiled
- * Windows x64 build with clang
- * MacOS
- 
+Nowdays there is builds on
+[CircleCI](https://circleci.com/gh/mpromonet/webrtc-streamer),
+[CirrusCI](https://cirrus-ci.com/github/mpromonet/webrtc-streamer) and
+[GitHub CI](https://github.com/mpromonet/webrtc-streamer/actions):
+
+- for x86_64 on Ubuntu Bionic
+- for armv7 crosscompiled (this build is running on Raspberry Pi2 and NanoPi
+  NEO)
+- for armv6+vfp crosscompiled (this build is running on Raspberry PiB and should
+  run on a Raspberry Zero)
+- for arm64 crosscompiled
+- Windows x64 build with clang
+- MacOS
+
 The webrtc stream name could be:
- * an alias defined using -n argument then the corresponding -u argument will be used to create the capturer
- * an "rtsp://" url that will be openned using an RTSP capturer based on live555
- * an "file://" url that will be openned using an MKV capturer based on live555
- * an "screen://" url that will be openned by webrtc::DesktopCapturer::CreateScreenCapturer 
- * an "window://" url that will be openned by webrtc::DesktopCapturer::CreateWindowCapturer 
- * an "v4l2://" url that will capture H264 frames and store it using webrtc::VideoFrameBuffer::Type::kNative type (obviously not supported on Windows)
- * a capture device name
+
+- an alias defined using -n argument then the corresponding -u argument will be
+  used to create the capturer
+- an "rtsp://" url that will be openned using an RTSP capturer based on live555
+- an "file://" url that will be openned using an MKV capturer based on live555
+- an "screen://" url that will be openned by
+  webrtc::DesktopCapturer::CreateScreenCapturer
+- an "window://" url that will be openned by
+  webrtc::DesktopCapturer::CreateWindowCapturer
+- an "v4l2://" url that will capture H264 frames and store it using
+  webrtc::VideoFrameBuffer::Type::kNative type (obviously not supported on
+  Windows)
+- a capture device name
 
 ## Dependencies
 
 It is based on:
- * [WebRTC Native Code Package](http://www.webrtc.org) for WebRTC
- * [civetweb HTTP server](https://github.com/civetweb/civetweb) for HTTP server
- * [live555](http://www.live555.com/liveMedia) for RTSP/MKV source
+
+- [WebRTC Native Code Package](http://www.webrtc.org) for WebRTC
+- [civetweb HTTP server](https://github.com/civetweb/civetweb) for HTTP server
+- [live555](http://www.live555.com/liveMedia) for RTSP/MKV source
 
 ## Build
+
 Install the Chromium depot tools (for WebRTC).
 
 ```sh
@@ -64,23 +80,26 @@ export PATH=$PATH:`realpath depot_tools`
 popd
 ```
 
-Download WebRTC 
+Download WebRTC
+
 ```sh
 mkdir ../webrtc
 pushd ../webrtc
 fetch --no-history webrtc 
 popd
 ```
-	
 
 Build WebRTC Streamer
+
 ```sh
 cmake . && make
 ```
 
-It is possible to specify cmake parameters `WEBRTCROOT` & `WEBRTCDESKTOPCAPTURE`:
- - `$WEBRTCROOT/src` should contains source (default is $(pwd)/../webrtc) 
- - `WEBRTCDESKTOPCAPTURE` enabling desktop capture if available (default is ON) 
+It is possible to specify cmake parameters `WEBRTCROOT` &
+`WEBRTCDESKTOPCAPTURE`:
+
+- `$WEBRTCROOT/src` should contains source (default is $(pwd)/../webrtc)
+- `WEBRTCDESKTOPCAPTURE` enabling desktop capture if available (default is ON)
 
 ## Usage
 
@@ -111,11 +130,17 @@ It is possible to specify cmake parameters `WEBRTCROOT` & `WEBRTCDESKTOPCAPTURE`
 	-q[filter]                         : spefify publish filter (default:.*)
 	-o                                 : use null codec (keep frame encoded)
 ```
- 
 
-Arguments of '-H' are forwarded to option [listening_ports](https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md#listening_ports-8080) of civetweb, then it is possible to use the civetweb syntax like `-H8000,9000` or `-H8080r,8443s`.
+Arguments of '-H' are forwarded to option
+[listening_ports](https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md#listening_ports-8080)
+of civetweb, then it is possible to use the civetweb syntax like `-H8000,9000`
+or `-H8080r,8443s`.
 
-Using `-o` allow to store compressed frame from backend stream using `webrtc::VideoFrameBuffer::Type::kNative`. This Hack the stucture `webrtc::VideoFrameBuffer` storing data in a override of i420 buffer. This allow to forward H264 frames from V4L2 device or RTSP stream to WebRTC stream. It use less CPU and have less adaptation (resize, codec, bandwidth are disabled).
+Using `-o` allow to store compressed frame from backend stream using
+`webrtc::VideoFrameBuffer::Type::kNative`. This Hack the stucture
+`webrtc::VideoFrameBuffer` storing data in a override of i420 buffer. This allow
+to forward H264 frames from V4L2 device or RTSP stream to WebRTC stream. It use
+less CPU and have less adaptation (resize, codec, bandwidth are disabled).
 
 Examples
 
@@ -123,17 +148,19 @@ Examples
 ./webrtc-streamer rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
 ```
 
-
 [![Screenshot](images/snapshot.png)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/)
 
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/)
 
-We can access to the WebRTC stream using [webrtcstreamer.html](https://github.com/mpromonet/webrtc-streamer-html/blob/master/webrtcstreamer.html). For instance:
+We can access to the WebRTC stream using
+[webrtcstreamer.html](https://github.com/mpromonet/webrtc-streamer-html/blob/master/webrtcstreamer.html).
+For instance:
 
-* https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtcstreamer.html?rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
-* https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtcstreamer.html?Bunny
+- https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtcstreamer.html?rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
+- https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/webrtcstreamer.html?Bunny
 
-An example displaying grid of WebRTC Streams is available using option "layout=<lines>x<columns>"
+An example displaying grid of WebRTC Streams is available using option
+"layout=<lines>x<columns>"
 [![Screenshot](images/layout2x4.png)](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/?layout=2x4)
 
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/?layout=2x4)
@@ -148,17 +175,27 @@ It is possible to start embeded ICE server and publish its url using:
 ./webrtc-streamer -S0.0.0.0:3478 -s$(curl -s ifconfig.me):3478 -T0.0.0.0:3479 -tturn:turn@$(curl -s ifconfig.me):3479
 ```
 
-The command `curl -s ifconfig.me` is getting the public IP, it could also given as a static parameter.
+The command `curl -s ifconfig.me` is getting the public IP, it could also given
+as a static parameter.
 
-In order to configure the NAT rules using the upnp feature of the router, it is possible to use [upnpc](https://manpages.debian.org/unstable/miniupnpc/upnpc.1.en.html) like this:
+In order to configure the NAT rules using the upnp feature of the router, it is
+possible to use
+[upnpc](https://manpages.debian.org/unstable/miniupnpc/upnpc.1.en.html) like
+this:
 
 ```sh
 upnpc -r 8000 tcp 3478 tcp 3478 udp
 ```
+
 Adapting with the HTTP port, STUN port, TURN port.
 
 ## Embed in a HTML page
-Instead of using the internal HTTP server, it is easy to display a WebRTC stream in a HTML page served by another HTTP server. The URL of the webrtc-streamer to use should be given creating the [WebRtcStreamer](http://htmlpreview.github.io/?https://github.com/mpromonet/webrtc-streamer-html/blob/master/jsdoc/WebRtcStreamer.html) instance:
+
+Instead of using the internal HTTP server, it is easy to display a WebRTC stream
+in a HTML page served by another HTTP server. The URL of the webrtc-streamer to
+use should be given creating the
+[WebRtcStreamer](http://htmlpreview.github.io/?https://github.com/mpromonet/webrtc-streamer-html/blob/master/jsdoc/WebRtcStreamer.html)
+instance:
 
 ```js
 var webRtcServer      = new WebRtcStreamer(<video tag>, <webrtc-streamer url>);
@@ -187,7 +224,9 @@ A short sample HTML page using webrtc-streamer running locally on port 8000:
 ```
 
 # Using WebComponent
-Using web-component could be a simple way to display some webrtc stream, a minimal page could be:
+
+Using web-component could be a simple way to display some webrtc stream, a
+minimal page could be:
 
 ```html
 <html>
@@ -199,7 +238,8 @@ Using web-component could be a simple way to display some webrtc stream, a minim
 </body>
 </html>
 ```
-[Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/Bunny.html)  
+
+[Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/Bunny.html)
 
 Using the webcomponent with a stream selector:
 
@@ -219,9 +259,12 @@ Using the webcomponent over google map:
 
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/tensorflow.html)
 
-
 ## Connect to Janus Gateway Video Room
-A simple way to publish WebRTC stream to a [Janus Gateway](https://janus.conf.meetecho.com) Video Room is to use the [JanusVideoRoom](http://htmlpreview.github.io/?https://github.com/mpromonet/webrtc-streamer-html/blob/master/jsdoc/JanusVideoRoom.html) interface
+
+A simple way to publish WebRTC stream to a
+[Janus Gateway](https://janus.conf.meetecho.com) Video Room is to use the
+[JanusVideoRoom](http://htmlpreview.github.io/?https://github.com/mpromonet/webrtc-streamer-html/blob/master/jsdoc/JanusVideoRoom.html)
+interface
 
 ```js
 var janus = new JanusVideoRoom(<janus url>, <webrtc-streamer url>)
@@ -246,20 +289,29 @@ A short sample to publish WebRTC streams to Janus Video Room could be:
 
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/janusvideoroom.html)
 
-This way the communication between [Janus API](https://janus.conf.meetecho.com/docs/JS.html) and [WebRTC Streamer API](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/help) is implemented in Javascript running in browser.
+This way the communication between
+[Janus API](https://janus.conf.meetecho.com/docs/JS.html) and
+[WebRTC Streamer API](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/help)
+is implemented in Javascript running in browser.
 
 The same logic could be implemented in NodeJS using the same JS API:
 
 ```js
-global.request = require('then-request');
-var JanusVideoRoom = require('./html/janusvideoroom.js'); 
-var janus = new JanusVideoRoom("http://192.168.0.15:8088/janus", "http://192.168.0.15:8000")
-janus.join(1234,"mmal service 16.1","video")
+global.request = require("then-request");
+var JanusVideoRoom = require("./html/janusvideoroom.js");
+var janus = new JanusVideoRoom(
+  "http://192.168.0.15:8088/janus",
+  "http://192.168.0.15:8000",
+);
+janus.join(1234, "mmal service 16.1", "video");
 ```
 
 ## Connect to Jitsi
 
-A simple way to publish WebRTC stream to a [Jitsi](https://meet.jit.si) Video Room is to use the [XMPPVideoRoom](http://htmlpreview.github.io/?https://github.com/mpromonet/webrtc-streamer-html/blob/master/jsdoc/XMPPVideoRoom.html) interface
+A simple way to publish WebRTC stream to a [Jitsi](https://meet.jit.si) Video
+Room is to use the
+[XMPPVideoRoom](http://htmlpreview.github.io/?https://github.com/mpromonet/webrtc-streamer-html/blob/master/jsdoc/XMPPVideoRoom.html)
+interface
 
 ```js
 var xmpp = new XMPPVideoRoom(<xmpp server url>, <webrtc-streamer url>)
@@ -287,6 +339,7 @@ A short sample to publish WebRTC streams to a Jitsi Video Room could be:
 [Live Demo](https://webrtcstreamer.agreeabletree-365b9a90.canadacentral.azurecontainerapps.io/xmppvideoroom.html)
 
 # Docker Image
+
 You can start the application using the docker image:
 
 ```sh
@@ -301,20 +354,17 @@ docker run --device=/dev/video0 -p 8000:8000 -it mpromonet/webrtc-streamer
 
 The container entry point is the webrtc-streamer application, then you can:
 
-* get the help using:
-	```sh
-	docker run -p 8000:8000 -it mpromonet/webrtc-streamer -h
-	```
-* run the container registering a RTSP url using:
+- get the help using:
+  ```sh
+  docker run -p 8000:8000 -it mpromonet/webrtc-streamer -h
+  ```
+- run the container registering a RTSP url using:
 
-	```sh
-    docker run -p 8000:8000 -it mpromonet/webrtc-streamer -n raspicam -u rtsp://pi2.local:8554/unicast
-	```
-* run the container giving config.json file using:
+  ```sh
+  docker run -p 8000:8000 -it mpromonet/webrtc-streamer -n raspicam -u rtsp://pi2.local:8554/unicast
+  ```
+- run the container giving config.json file using:
 
-	```sh
-    docker run -p 8000:8000 -v $PWD/config.json:/app/config.json mpromonet/webrtc-streamer
-	```
-
-
-
+  ```sh
+  docker run -p 8000:8000 -v $PWD/config.json:/app/config.json mpromonet/webrtc-streamer
+  ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-	<a href="http://wiki.friendlyarm.com/wiki/index.php/NanoPi_NEO_Air"><img src="images/nanopi.jpg" width="500"></a>
+	<a href="https://wiki.friendlyelec.com/wiki/index.php/NanoPi_NEO_Air"><img src="images/nanopi.jpg" width="500"></a>
 	<h1>WebRTC-Streamer</h1>
 </div>
 


### PR DESCRIPTION
## Description

This:
- Fixes some typos
- Removes the broken Codacy badge & replaces the broken heroku badge
- Formats it using [deno's code formatter](https://deno.land/manual@v1.29.3/tools/formatter)
- Adds syntax highlighting to most code blocks
- Uses opinionated markdown syntax (preferring `#` over `==========`, `-` over `*` for lists) -- this causes less markdown errors and should be preferred.

## Motivation and Context

The README, at first glance, can look very confusing. This aims to alleviate some of the pain of that.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring
