### PR TITLE
docs(readme): clarify size for webrtc

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ dependencies above:
    export PATH=$PATH:`realpath depot_tools`
    popd
    ```
-2. Download WebRTC
+2. Download WebRTC (do note that this may take a while, since the WebRTC dependency is large).
 
    ```sh
    mkdir ../webrtc


### PR DESCRIPTION
When I was building the repository locally, I was stunned by how long it took, and realized that it was simply due to the massive size of the WebRTC dependency even ignoring history. Clarification here can possibly help other people too.
