### PR TITLE
docs: detail different endpoints

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,10 +2,23 @@
 
 The WebRTC signaling is implemented through HTTP requests:
 
- - /api/call   : send offer and get answer
- - /api/hangup : close a call
+ - `/api/call?peerid=<peerid>`   : send offer (through body) and get answer (JSON)
+ - `/api/hangup?peerid=<peerid>` : close a call
 
- - /api/addIceCandidate : add a candidate
- - /api/getIceCandidate : get the list of candidates
+ - `/api/createOffer` :
+ - `/api/setAnswer` : 
 
-The list of HTTP API is available using /api/help.
+ - `/api/getIceServers` : get object of ICE servers
+ - `/api/getStreamList` : gets currently active streams
+ - `/api/getVideoDeviceList` : gets list of streamable video devices
+ - `/api/getAudioDeviceList` : get list of streamable audio devices
+ - `/api/getPeerConnectionList` : get list of active WebRTC peer connections
+- `/api/getMediaList` : get list of combined audio and video strings in objects
+
+ - `/api/addIceCandidate?peerid=<peerId>` : add a candidate
+ - `/api/getIceCandidate?peerid=<peerId>` : get the list of candidates
+ 
+ - `/api/version` : get current webrtc-streamer version
+ - `/api/log` : 
+
+The list of HTTP API endpoints is available using `/api/help`.


### PR DESCRIPTION
## Description

webrtc-streamer is lacking good information for their API endpoints.

## Related Issue

As detailed by #555, the JS files provided are meant as examples to make your own implementation, but when trying to use it in different languages it gets confusing.

## Motivation and Context

I do aim to improve documentation by detailing endpoints, but I am also furthermore confused about some endpoints.

I've begun with some, and I think it would be great to detail more, as well as how to implement your own webrtc-streamer client.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
