### PR TITLE
Try h265

### DIFF
--- a/inc/EncodedVideoFrameBuffer.h
+++ b/inc/EncodedVideoFrameBuffer.h
@@ -17,29 +17,30 @@
 class EncodedVideoI420Buffer : public webrtc::I420BufferInterface
 {
 public:
-  EncodedVideoI420Buffer(int width, int height, const rtc::scoped_refptr<webrtc::EncodedImageBufferInterface> &encoded_data) : width_(width), height_(height), encoded_data_(encoded_data)
-  {
-  }
-  virtual int width() const { return width_; }
-  virtual int height() const { return height_; }
-  virtual const uint8_t *DataY() const { return encoded_data_->data(); }
+  EncodedVideoI420Buffer(int width, int height, const rtc::scoped_refptr<webrtc::EncodedImageBufferInterface> &encoded_data, webrtc::VideoFrameType frameType) 
+    : m_width(width), m_height(height), m_encoded_data(encoded_data), m_frameType(frameType) {}
+  virtual int width() const { return m_width; }
+  virtual int height() const { return m_height; }
+  virtual const uint8_t *DataY() const { return m_encoded_data->data(); }
   virtual const uint8_t *DataU() const { return NULL; }
   virtual const uint8_t *DataV() const { return NULL; }
-  virtual int StrideY() const { return encoded_data_->size(); }
+  virtual int StrideY() const { return m_encoded_data->size(); }
   virtual int StrideU() const { return 0; }
   virtual int StrideV() const { return 0; }
+  webrtc::VideoFrameType getFrameType() const { return m_frameType; }
 
 private:
-  const int width_;
-  const int height_;
-  rtc::scoped_refptr<webrtc::EncodedImageBufferInterface> encoded_data_;
+  const int m_width;
+  const int m_height;
+  rtc::scoped_refptr<webrtc::EncodedImageBufferInterface> m_encoded_data;
+  webrtc::VideoFrameType m_frameType;
 };
 
 class EncodedVideoFrameBuffer : public webrtc::VideoFrameBuffer
 {
 public:
-  EncodedVideoFrameBuffer(int width, int height, const rtc::scoped_refptr<webrtc::EncodedImageBufferInterface> &encoded_data)
-    : buffer_(new rtc::RefCountedObject<EncodedVideoI420Buffer>(width, height, encoded_data)) {}
+  EncodedVideoFrameBuffer(int width, int height, const rtc::scoped_refptr<webrtc::EncodedImageBufferInterface> &encoded_data, webrtc::VideoFrameType frameType)
+    : buffer_(new rtc::RefCountedObject<EncodedVideoI420Buffer>(width, height, encoded_data, frameType)) {}
   virtual Type type() const { return webrtc::VideoFrameBuffer::Type::kNative; }
   virtual rtc::scoped_refptr<webrtc::I420BufferInterface> ToI420() { return webrtc::I420Buffer::Create(width(), height()); }
   virtual int width() const { return buffer_->width(); }

--- a/inc/NullDecoder.h
+++ b/inc/NullDecoder.h
@@ -37,13 +37,17 @@ class NullDecoder : public webrtc::VideoDecoder {
 			return WEBRTC_VIDEO_CODEC_UNINITIALIZED;
 		}
 		rtc::scoped_refptr<webrtc::EncodedImageBufferInterface> encodedData = input_image.GetEncodedData();
-		rtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer = rtc::make_ref_counted<EncodedVideoFrameBuffer>(m_settings.max_render_resolution().Width(), m_settings.max_render_resolution().Height(), encodedData);
+		rtc::scoped_refptr<webrtc::VideoFrameBuffer> frameBuffer = rtc::make_ref_counted<EncodedVideoFrameBuffer>(m_settings.max_render_resolution().Width(), m_settings.max_render_resolution().Height(), encodedData, input_image._frameType);
 		
-		webrtc::VideoFrame frame(buffer, webrtc::kVideoRotation_0, render_time_ms * rtc::kNumMicrosecsPerMillisec);
-		frame.set_timestamp(input_image.Timestamp());
-		frame.set_ntp_time_ms(input_image.NtpTimeMs());
+		webrtc::VideoFrame frame = webrtc::VideoFrame::Builder()
+					.set_video_frame_buffer(frameBuffer)
+					.set_rotation(webrtc::kVideoRotation_0)
+					.set_timestamp_rtp(input_image.Timestamp())
+					.set_timestamp_ms(render_time_ms)
+					.set_ntp_time_ms(input_image.NtpTimeMs())
+					.build();
 
-		RTC_LOG(LS_VERBOSE) << "Decode " << frame.id() << " " << input_image._frameType << " " <<  buffer->width() << "x" <<  buffer->height() << " " <<  buffer->GetI420()->StrideY();
+		RTC_LOG(LS_VERBOSE) << "Decode " << frame.id() << " " << input_image._frameType << " " <<  frameBuffer->width() << "x" <<  frameBuffer->height() << " " <<  frameBuffer->GetI420()->StrideY();
 
 		m_decoded_image_callback->Decoded(frame);
 

--- a/inc/V4l2Capturer.h
+++ b/inc/V4l2Capturer.h
@@ -134,7 +134,8 @@ private:
 				}
 
 				int64_t ts = std::chrono::high_resolution_clock::now().time_since_epoch().count()/1000/1000;
-				rtc::scoped_refptr<webrtc::VideoFrameBuffer> frameBuffer = rtc::make_ref_counted<EncodedVideoFrameBuffer>(m_capture->getWidth(), m_capture->getHeight(), encodedData);
+				webrtc::VideoFrameType frameType = idr ? webrtc::VideoFrameType::kVideoFrameKey : webrtc::VideoFrameType::kVideoFrameDelta;
+				rtc::scoped_refptr<webrtc::VideoFrameBuffer> frameBuffer = rtc::make_ref_counted<EncodedVideoFrameBuffer>(m_capture->getWidth(), m_capture->getHeight(), encodedData, frameType);
 				webrtc::VideoFrame frame = webrtc::VideoFrame::Builder()
 					.set_video_frame_buffer(frameBuffer)
 					.set_rotation(webrtc::kVideoRotation_0)

--- a/inc/VideoDecoder.h
+++ b/inc/VideoDecoder.h
@@ -20,14 +20,6 @@
 #include "SessionSink.h"
 #include "VideoScaler.h"
 
-#define FOURCC(a, b, c, d)                                \
-  ((static_cast<uint32_t>(a)) | (static_cast<uint32_t>(b) << 8) | \
-   (static_cast<uint32_t>(c) << 16) | (static_cast<uint32_t>(d) << 24))
-
-const uint32_t FOURCC_VP9 = FOURCC('V','P','9', 0);
-const uint32_t FOURCC_H265 = FOURCC('H','2','6','5');
-#undef FOURCC
-
 class VideoDecoder : public rtc::VideoSourceInterface<webrtc::VideoFrame>, public webrtc::DecodedImageCallback {
     private:
         class Frame
@@ -35,12 +27,14 @@ class VideoDecoder : public rtc::VideoSourceInterface<webrtc::VideoFrame>, publi
             public:
                 Frame(): m_timestamp_ms(0) {}
                 Frame(const rtc::scoped_refptr<webrtc::EncodedImageBuffer> & content, uint64_t timestamp_ms, webrtc::VideoFrameType frameType) : m_content(content), m_timestamp_ms(timestamp_ms), m_frameType(frameType) {}
-                Frame(const cricket::VideoFormat & format) : m_format(format) {}
+                Frame(const std::string & format, int width, int height) : m_format(format), m_width(width), m_height(height) {}
             
                 rtc::scoped_refptr<webrtc::EncodedImageBuffer>   m_content;
-                uint64_t               m_timestamp_ms;
-                webrtc::VideoFrameType m_frameType;
-                cricket::VideoFormat   m_format;
+                uint64_t                                         m_timestamp_ms;
+                webrtc::VideoFrameType                           m_frameType;
+                std::string                                      m_format;
+                int                                              m_width;
+                int                                              m_height;
         };
 
     public:
@@ -134,8 +128,8 @@ class VideoDecoder : public rtc::VideoSourceInterface<webrtc::VideoFrame>, publi
             return frames;
         }
 
-        void postFormat(const cricket::VideoFormat & format) {
-			Frame frame(format);			
+        void postFormat(const std::string & format, int width, int height) {
+            Frame frame(format, width, height);
 			{
 				std::unique_lock<std::mutex> lock(m_queuemutex);
 				m_queue.push(frame);
@@ -195,17 +189,17 @@ class VideoDecoder : public rtc::VideoSourceInterface<webrtc::VideoFrame>, publi
             return (m_decoder.get() != NULL);
         }
 
-        void createDecoder(const cricket::VideoFormat & format) {
+        void createDecoder(const std::string & format, int width, int height) {
             webrtc::VideoDecoder::Settings settings;
-            webrtc::RenderResolution resolution(format.width, format.height);
+            webrtc::RenderResolution resolution(width, height);
             settings.set_max_render_resolution(resolution);
-            if (format.fourcc == cricket::FOURCC_H264) {
+            if (format == "H264") {
                 m_decoder=m_factory->CreateVideoDecoder(webrtc::SdpVideoFormat(cricket::kH264CodecName));
                 settings.set_codec_type(webrtc::VideoCodecType::kVideoCodecH264);
-            } else if (format.fourcc == FOURCC_H265) {
-                m_decoder=m_factory->CreateVideoDecoder(webrtc::SdpVideoFormat("H265"));
+            } else if (format == "H265") {
+                m_decoder=m_factory->CreateVideoDecoder(webrtc::SdpVideoFormat(format));
                 settings.set_codec_type(webrtc::VideoCodecType::kVideoCodecGeneric);
-            } else if (format.fourcc == FOURCC_VP9) {
+            } else if (format == "VP9") {
                 m_decoder=m_factory->CreateVideoDecoder(webrtc::SdpVideoFormat(cricket::kVp9CodecName));
                 settings.set_codec_type(webrtc::VideoCodecType::kVideoCodecVP9);	                
             }
@@ -232,21 +226,22 @@ class VideoDecoder : public rtc::VideoSourceInterface<webrtc::VideoFrame>, publi
             while (!m_stop) {
                 Frame frame = this->getFrame();
 
-                if (frame.m_format.fourcc != 0) {
-                    cricket::VideoFormat & format = frame.m_format;
+                if (!frame.m_format.empty()) {
 
                     if (this->hasDecoder()) {
-                        if ((m_format.width != format.width) || (m_format.height != format.height)) {
-                            RTC_LOG(LS_INFO) << "format changed => set format from " << m_format.ToString() << " to " << format.ToString();
+                        if ((m_format != frame.m_format) || (m_width != frame.m_width) || (m_height != frame.m_height)) {
+                            RTC_LOG(LS_INFO) << "format changed => set format from " << m_format << " " << m_width << "x" << m_height << " to " << frame.m_format << " " << frame.m_width << "x" << frame.m_height;
                             m_decoder.reset(NULL);
                         }
                     }
 
                     if (!this->hasDecoder()) {
-                        RTC_LOG(LS_INFO) << "VideoDecoder:DecoderThread set format:" << format.ToString();
-                        m_format = format;
+                        RTC_LOG(LS_INFO) << "VideoDecoder:DecoderThread set format:" << frame.m_format << " " << frame.m_width << "x" << frame.m_height;
+                        m_format = frame.m_format;
+                        m_width = frame.m_width;
+                        m_height = frame.m_height;
 
-                        this->createDecoder(format);
+                        this->createDecoder(frame.m_format, frame.m_width, frame.m_height);
                     }
                 }                
 
@@ -300,7 +295,10 @@ class VideoDecoder : public rtc::VideoSourceInterface<webrtc::VideoFrame>, publi
     protected:
         VideoScaler                                   m_scaler;
         std::unique_ptr<webrtc::VideoDecoderFactory>& m_factory;
-        cricket::VideoFormat m_format;
+
+        std::string                          m_format;
+        int                                  m_width;
+        int                                  m_height;
 
 		std::queue<Frame>                     m_queue;
 		std::mutex                            m_queuemutex;

--- a/inc/VideoDecoderFactory.h
+++ b/inc/VideoDecoderFactory.h
@@ -14,7 +14,7 @@
 
 class VideoDecoderFactory : public webrtc::VideoDecoderFactory {
    public:
-    VideoDecoderFactory(): supported_formats_({webrtc::SdpVideoFormat(cricket::kH264CodecName)}) {}
+    VideoDecoderFactory(): supported_formats_({webrtc::SdpVideoFormat(cricket::kH264CodecName),webrtc::SdpVideoFormat("H265")}) {}
     virtual ~VideoDecoderFactory() override {}
 
     std::unique_ptr<webrtc::VideoDecoder> CreateVideoDecoder(const webrtc::SdpVideoFormat& format) override {

--- a/inc/VideoEncoderFactory.h
+++ b/inc/VideoEncoderFactory.h
@@ -17,7 +17,7 @@
 
 class VideoEncoderFactory : public webrtc::VideoEncoderFactory {
    public:
-    VideoEncoderFactory(): supported_formats_({webrtc::SdpVideoFormat(cricket::kH264CodecName)}) {}
+    VideoEncoderFactory(): supported_formats_({webrtc::SdpVideoFormat(cricket::kH264CodecName),webrtc::SdpVideoFormat("H265")}) {}
     virtual ~VideoEncoderFactory() override {}
 
     std::unique_ptr<webrtc::VideoEncoder> CreateVideoEncoder(const webrtc::SdpVideoFormat& format) override {

--- a/inc/livevideosource.h
+++ b/inc/livevideosource.h
@@ -132,8 +132,7 @@ public:
                     {
                         int fps = 25;
                         RTC_LOG(LS_INFO) << "LiveVideoSource:onData SPS set format " << sps->width << "x" << sps->height << " fps:" << fps;
-                        cricket::VideoFormat videoFormat(sps->width, sps->height, cricket::VideoFormat::FpsToInterval(fps), cricket::FOURCC_H264);
-                        m_decoder.postFormat(videoFormat);
+                        m_decoder.postFormat(codec, sps->width, sps->height);
                     }
                 }
                 else if (nalu_type == webrtc::H264::NaluType::kPps)
@@ -188,8 +187,7 @@ public:
                     RTC_LOG(LS_VERBOSE) << "LiveVideoSource:onData SPS";
                     m_cfg.insert(m_cfg.end(), buffer + index.start_offset, buffer + index.payload_size + index.payload_start_offset);
 
-                    cricket::VideoFormat videoFormat(0, 0, cricket::VideoFormat::FpsToInterval(0), FOURCC_H265);
-                    m_decoder.postFormat(videoFormat);
+                    m_decoder.postFormat(codec, 0, 0);
                 }
                 else if (nalu_type == webrtc::H265::NaluType::kPps)
                 {
@@ -265,8 +263,7 @@ public:
         }
         else if (codec == "VP9")
         {
-            cricket::VideoFormat videoFormat(0, 0, cricket::VideoFormat::FpsToInterval(0), FOURCC_VP9);
-            m_decoder.postFormat(videoFormat);
+            m_decoder.postFormat(codec, 0, 0);
 
             webrtc::VideoFrameType frameType = webrtc::VideoFrameType::kVideoFrameKey;
             rtc::scoped_refptr<webrtc::EncodedImageBuffer> frame = webrtc::EncodedImageBuffer::Create(buffer, size);

--- a/inc/livevideosource.h
+++ b/inc/livevideosource.h
@@ -26,9 +26,11 @@
 #include "media/base/video_broadcaster.h"
 #include "media/engine/internal_decoder_factory.h"
 
+#include "common_video/h265/h265_common.h"
+#include "common_video/h265/h265_sps_parser.h"
+
 #include "common_video/h264/h264_common.h"
 #include "common_video/h264/sps_parser.h"
-#include "modules/video_coding/h264_sprop_parameter_sets.h"
 
 #include "api/video_codecs/video_decoder.h"
 
@@ -75,6 +77,7 @@ public:
             RTC_LOG(LS_INFO) << "LiveVideoSource::onNewSession id:"<< id << " media:" << media << "/" << codec << " sdp:" << sdp;
 
             if ( (strcmp(codec, "H264") == 0)
+               || (strcmp(codec, "H265") == 0)              
                || (strcmp(codec, "JPEG") == 0)
                || (strcmp(codec, "VP9") == 0) )
             {
@@ -97,7 +100,7 @@ public:
         }
         return success;
     }
-
+    
     virtual bool onData(const char *id, unsigned char *buffer, ssize_t size, struct timeval presentationTime)
     {
         int64_t ts = presentationTime.tv_sec;
@@ -146,6 +149,58 @@ public:
                     webrtc::VideoFrameType frameType = webrtc::VideoFrameType::kVideoFrameDelta;
                     std::vector<uint8_t> content;
                     if (nalu_type == webrtc::H264::NaluType::kIdr)
+                    {
+                        frameType = webrtc::VideoFrameType::kVideoFrameKey;
+                        RTC_LOG(LS_VERBOSE) << "LiveVideoSource:onData IDR";
+                        content.insert(content.end(), m_cfg.begin(), m_cfg.end());
+                    }
+                    else
+                    {
+                        RTC_LOG(LS_VERBOSE) << "LiveVideoSource:onData SLICE NALU:" << nalu_type;
+                    }
+                    if (m_prevTimestamp && ts < m_prevTimestamp && m_decoder.m_decoder && strcmp(m_decoder.m_decoder->ImplementationName(),"FFmpeg")==0) 
+                    {
+                        RTC_LOG(LS_ERROR) << "LiveVideoSource:onData drop frame in past for FFmpeg:" << (m_prevTimestamp-ts);
+
+                    } else {
+                        content.insert(content.end(), buffer + index.start_offset, buffer + index.payload_size + index.payload_start_offset);
+                        rtc::scoped_refptr<webrtc::EncodedImageBuffer> frame = webrtc::EncodedImageBuffer::Create(content.data(), content.size());
+                        m_decoder.PostFrame(frame, ts, frameType);
+                    }
+                }
+            }
+        }
+        else if (codec == "H265")
+        {
+            std::vector<webrtc::H265::NaluIndex> indexes = webrtc::H265::FindNaluIndices(buffer,size);
+            RTC_LOG(LS_VERBOSE) << "LiveVideoSource:onData nbNalu:" << indexes.size();
+            for (const webrtc::H265::NaluIndex & index : indexes) {
+                webrtc::H265::NaluType nalu_type = webrtc::H265::ParseNaluType(buffer[index.payload_start_offset]);
+                RTC_LOG(LS_VERBOSE) << "LiveVideoSource:onData NALU type:" << nalu_type << " payload_size:" << index.payload_size << " payload_start_offset:" << index.payload_start_offset << " start_offset:" << index.start_offset;
+                if (nalu_type == webrtc::H265::NaluType::kVps)
+                {
+                    RTC_LOG(LS_VERBOSE) << "LiveVideoSource:onData VPS";
+                    m_cfg.clear();
+                    m_cfg.insert(m_cfg.end(), buffer + index.start_offset, buffer + index.payload_size + index.payload_start_offset);
+                }
+                else if (nalu_type == webrtc::H265::NaluType::kSps)
+                {
+                    RTC_LOG(LS_VERBOSE) << "LiveVideoSource:onData SPS";
+                    m_cfg.insert(m_cfg.end(), buffer + index.start_offset, buffer + index.payload_size + index.payload_start_offset);
+
+                    cricket::VideoFormat videoFormat(0, 0, cricket::VideoFormat::FpsToInterval(0), FOURCC_H265);
+                    m_decoder.postFormat(videoFormat);
+                }
+                else if (nalu_type == webrtc::H265::NaluType::kPps)
+                {
+                    RTC_LOG(LS_VERBOSE) << "LiveVideoSource:onData PPS";
+                    m_cfg.insert(m_cfg.end(), buffer + index.start_offset, buffer + index.payload_size + index.payload_start_offset);
+                }
+                else
+                {
+                    webrtc::VideoFrameType frameType = webrtc::VideoFrameType::kVideoFrameDelta;
+                    std::vector<uint8_t> content;
+                    if ( (nalu_type == webrtc::H265::NaluType::kIdrWRadl) || (nalu_type == webrtc::H265::NaluType::kIdrNLp) )
                     {
                         frameType = webrtc::VideoFrameType::kVideoFrameKey;
                         RTC_LOG(LS_VERBOSE) << "LiveVideoSource:onData IDR";

--- a/inc/livevideosource.h
+++ b/inc/livevideosource.h
@@ -126,12 +126,11 @@ public:
                     if (!sps)
                     {
                         RTC_LOG(LS_ERROR) << "cannot parse sps";
-                        res = -1;
+                        m_decoder.postFormat(codec, 0, 0);
                     }
                     else
                     {
-                        int fps = 25;
-                        RTC_LOG(LS_INFO) << "LiveVideoSource:onData SPS set format " << sps->width << "x" << sps->height << " fps:" << fps;
+                        RTC_LOG(LS_INFO) << "LiveVideoSource:onData SPS set format " << sps->width << "x" << sps->height;
                         m_decoder.postFormat(codec, sps->width, sps->height);
                     }
                 }
@@ -187,7 +186,17 @@ public:
                     RTC_LOG(LS_VERBOSE) << "LiveVideoSource:onData SPS";
                     m_cfg.insert(m_cfg.end(), buffer + index.start_offset, buffer + index.payload_size + index.payload_start_offset);
 
-                    m_decoder.postFormat(codec, 0, 0);
+                    absl::optional<webrtc::H265SpsParser::SpsState> sps = webrtc::H265SpsParser::ParseSps(buffer + index.payload_start_offset, index.payload_size);
+                    if (!sps)
+                    {
+                        RTC_LOG(LS_ERROR) << "cannot parse sps";
+                        m_decoder.postFormat(codec, 0, 0);
+                    }
+                    else
+                    {
+                        RTC_LOG(LS_INFO) << "LiveVideoSource:onData SPS set format " << sps->width << "x" << sps->height;
+                        m_decoder.postFormat(codec, sps->width, sps->height);
+                    }
                 }
                 else if (nalu_type == webrtc::H265::NaluType::kPps)
                 {

--- a/inc/rtmpvideosource.h
+++ b/inc/rtmpvideosource.h
@@ -120,8 +120,7 @@ private:
                     RTC_LOG(LS_ERROR) << "sps " << sps->width << "x" << sps->height;
                     int fps = 25;
                     RTC_LOG(LS_INFO) << "RtmpVideoSource:onData SPS set format " << sps->width << "x" << sps->height << " fps:" << fps;
-                    cricket::VideoFormat videoFormat(sps->width, sps->height, cricket::VideoFormat::FpsToInterval(fps), cricket::FOURCC_H264);
-                    m_decoder.postFormat(videoFormat);
+                    m_decoder.postFormat("H264", sps->width, sps->height);
                     
                     m_cfg.insert(m_cfg.end(), H26X_marker, H26X_marker+sizeof(H26X_marker));
                     m_cfg.insert(m_cfg.end(), &body[13], &body[13 + spssize + 1]);


### PR DESCRIPTION
## Description

This pull request try to use recently support h265 parsing in webrtc SDK, with -o it forward h265 packet from RTSP to WebRTC.
It needs a web browser that support webrtc with h265 to validate and improve it.

<!--- Describe your changes in detail -->

## Related Issue

https://github.com/mpromonet/webrtc-streamer/issues/600
https://github.com/mpromonet/webrtc-streamer/issues/611

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
